### PR TITLE
Add python tutorials articles

### DIFF
--- a/source/_posts/conda.md
+++ b/source/_posts/conda.md
@@ -1,0 +1,541 @@
+---
+title: Python笔记：Conda常用命令
+date: 2024-10-9 20:25:57
+tags:
+  - conda
+  - python
+  - tutorial
+categories:
+  - 笔记
+---
+
+> conda 是个复杂的 Python 版本管理隔离工具，这里我只是简单介绍一些 Conda 的常用命令，详细请参考：[命令 — conda 24.7.1 文档](https://docs.conda.org.cn/projects/conda/en/stable/commands/index.html) 。
+
+## 管理conda
+
+### 1. 帮助指南
+
+#### 🛠️ 获取帮助
+当我们不确定某个`conda`命令的具体用法时，可以通过添加`-h`或`--help`参数来查看该命令的使用说明：
+
+```cmd
+conda [order_name] -h
+conda [order_name] --help
+conda create --help		# Example: show <create> usage
+```
+
+#### 🔍 信息查询
+当我们想要了解**Conda**本身或环境的基本信息时，可以使用`conda info`命令。该命令也支持添加参数以获取更准确的输出：
+
+```cmd
+conda info		# Example: show .condarc
+```
+
+`conda info`常用查询参数：
+
+| 查询参数     | 功能                        |
+| ------------ | --------------------------- |
+| *`--envs`*   | 列出当前用户已知的Conda环境 |
+| *`--system`* | 显示系统级环境变量信息      |
+
+此外，**Conda**也支持查询所有Python环境的相关信息（<span style='color:gray'>如果以管理员身份运行，**Conda**会查询全部用户的所有Python环境</span>）：
+
+```cmd
+conda search --envs
+```
+
+### 2. 配置概述
+
+**Conda**有两种管理配置信息的方式，一种是通过`conda config`指令管理，另一种是通过编辑`.condarc`文件管理。值得一提的是`.xxxrc`在计算机领域很常见，`rc`是`Resource Configuration`的缩写，通常用作<span style='color: cyan'>存储应用程序</span>或<span style='color: cyan'>命令行工具</span>的用户偏好设置和配置选项，例如：`.npmrc`、`.nvmrc`。
+
+#### ⚙ 使用`conda config`命令配置
+查看**Conda**环境配置的方法有两种：一种是`--show`，该命令只会查询字段的**当前配置** ；另一种是`--get`，该命令可以查看对该字段进行变更的<span style='color: cyan'>**指令记录** </span>。
+
+```shell
+# Show all config
+conda config --show
+
+# Show [field_name] config
+conda config --show [field_name]	
+conda config --get [field_name]
+
+# Example: check channels config
+conda config --show channels
+conda condig --get channels
+```
+
+查看**Conda**环境配置字段的**含义**以及**当前配置**：
+
+```shell
+conda config --describe [field_name]
+
+# Example: show channels describe
+conda config --describe channels
+```
+
+管理**Conda**环境配置数据，需要注意的有：`--add`与`--prepend`实现的效果是一样的；`--add`等操作是用于<span style='color: cyan'>**数组类型**</span>，而`--set`是用于<span style='color: cyan'>**值类型**</span>。
+
+```shell
+conda config --append <Key> [Value]
+
+# Next two order equals to each other
+conda config --prepend <Key> [Value]
+conda config --add <Key> [Value]
+
+const config --set <Key> [Value]
+
+# Useful for '--add' and '--set'
+conda config --remove <Key> [Value]
+conda config --remove-key <Key> [Value]
+
+# Example: add mirror-source to channels
+conda config --add channels [source_url]
+
+# # Result:
+# # channels:
+# # 	- [source_url]
+
+
+# Example: add conda-forge to custom_channels
+conda config --set custom_channels.conda-forge [source_url]
+
+# # Result:
+# # custom_channels:
+# # 	conda-forge: [source_url]
+```
+
+#### 📝 编辑`.condarc`文件
+当我们使用`conda info`查看当前**Conda**的信息时，可以看见以下两个信息：
+
+|    user config file    | populated config files |
+| :--------------------: | :--------------------: |
+| C:\Users\lzz\\.condarc | C:\Users\lzz\\.condarc |
+
+其中`populated config files`是指当前**Conda**运行实例**已加载的Conda配置信息**我们可以编辑**windows**的环境变量，来实现加载项目目录中`.condarc`文件的目的。
+
+```shell
+set CONDARC=%CD%\.condarc		# Add condarc path
+set CONDARC=				# Remove condarc path
+```
+
+我们也可以根据**Conda**提供的`.condarc`查找策略来设置`.condarc`文件路径：
+
+```python
+if on_win:
+SEARCH_PATH = (
+  "C:/ProgramData/conda/.condarc",
+  "C:/ProgramData/conda/condarc",
+  "C:/ProgramData/conda/condarc.d",
+)
+else:
+SEARCH_PATH = (
+  "/etc/conda/.condarc",
+  "/etc/conda/condarc",
+  "/etc/conda/condarc.d/",
+  "/var/lib/conda/.condarc",
+  "/var/lib/conda/condarc",
+  "/var/lib/conda/condarc.d/",
+)
+
+SEARCH_PATH += (
+  "$CONDA_ROOT/.condarc",
+  "$CONDA_ROOT/condarc",
+  "$CONDA_ROOT/condarc.d/",
+  "$XDG_CONFIG_HOME/conda/.condarc",
+  "$XDG_CONFIG_HOME/conda/condarc",
+  "$XDG_CONFIG_HOME/conda/condarc.d/",
+  "~/.config/conda/.condarc",
+  "~/.config/conda/condarc",
+  "~/.config/conda/condarc.d/",
+  "~/.conda/.condarc",
+  "~/.conda/condarc",
+  "~/.conda/condarc.d/",
+  "~/.condarc",
+  "$CONDA_PREFIX/.condarc",
+  "$CONDA_PREFIX/condarc",
+  "$CONDA_PREFIX/condarc.d/",
+  "$CONDARC",
+)
+```
+
+当有多个`populated config files`存在时，也就是**Conda**读入了多个`.condarc`文件时，**Conda**遵循以下优先策略：
+
+* 当配置值是数组或者列表时按优先级合并，若为原始值时保留到优先级高的配置；
+* 各`.condarc`优先级由低到高依次为：解析器的`.condarc` → $CONDARC 指定的`.condarc` → `config order`参数 → <span style='color:  silver'><u>环境变量</u></span>；
+
+当我们使用`conda config`编辑`.condarc`文件时，可以通过`--system`、`--env`、`--file [file_name]`来指定配置输出位置：
+
+| 参数                                                         | 功能                                                         |
+| ------------------------------------------------------------ | ------------------------------------------------------------ |
+| *`--system`*                                                 | [**默认选项**] 输出到`User Config File`（`C:\Users\lzz\.condarc`）中 |
+| *`--env`*                                                    | 输出到当前活动环境下的`.condarc`中，如果没有则同`--system`   |
+| *<span style='white-space: nowrap'>`--file [filename]`</span>* | 输出到指定`.condarc`文件中                                   |
+
+### 3. 版本与更新
+
+我们可以使用如下指令<u>查看</u>，<u>更新</u>**Conda**版本。
+
+```cmd
+# Check conda version
+conda -V
+conda --version
+
+# Update conda
+conda update conda	
+
+# Update Anaconda
+conda update Anaconda	
+```
+
+### 4. 通道配置
+
+**Conda**官方的库提供的Python包较少，有时需要到第三方社区维护的**Conda**通道去找寻相关的Python包，例如：<u>conda-forge</u> 、<u>bioconda</u> 。故我们需要配置 *default_channels* 与 *custom_channels* 为**Conda**提供多个下载通道。
+
+值得一提的是，在使用**Conda**管理的Python 项目也可以使用`pip`安装所需的包，但是这种`conda install`与`pip install`混用的情况很容易导致库的依赖关系混乱。
+
+🔗 **设置官方通道及其镜像通道**
+
+我们打开`.condarc`后会发现**Conda**自动帮我们加入了`channels: -default`，而且官方通道的地址不是在`.condarc`中配置的，故我们只需要配置官方通道的镜像源即可。
+
+我们可以直接在 *channels* 里面添加官方通道的镜像源：
+
+```shell
+conda config --add channels [channel_url]
+```
+
+也可以将官方通道的镜像源添加到 *default_channels* 里面，以便与<u>conda-forge</u>等第三方社区通道区分开来：
+
+```shell
+conda config --add default_channels [channel_url]
+```
+
+#### 🧱 添加社区通道
+使用第三方社区通道（如 <u>conda-forge</u>），我们需要配置`channels: -[community_name]`：
+
+```shell
+conda config --add channels [community_name]
+
+# Example: add conda-forge community channel
+conda config --add channels conda-forge
+```
+
+对于第三方社区通道的地址，我们通常不用配置镜像源直接配置其地址即可。需要注意的是使用命令行工具添加配置的过程较为特殊，这里建议直接修改`.condarc`即可。可别忘了`--add`于`--set`的区别。
+
+```shell
+conda config --set custom_channels.[community_name] [channel_url]
+
+# Example: add conda-forge upon custom_channels
+conda config --set custom_channels.conda-forge 
+					http://mirrors.aliyun.com/anaconda/cloud
+```
+
+指定第三方社区通道下载包：
+
+```shell
+conda install [package_name] --channel [community_name]
+conda install [package_name] -c [community_name]
+
+# Example: use conda-forge install GDAL
+conda install GDAL --channel conda-forge
+```
+
+#### 🎯 优先级问题
+关于 *channels* 的优先级问题，我们可以使用`--describe`去查看**Conda**官方的介绍。*channels* 中越靠前优先级越高，`--prepend`、`--append`来控制 *channel* 的插入顺序。当**Conda**要下载东西的时候便会从优先级高的通道<span style='color: cyan'>依次查找</span>到优先级低的通道。 
+
+我们可以通过改变`channel_priority`配置来改变**Conda**下载策略：
+
+* *flexible*：只要在 ***所有通道*** 中找到了对应库便下载，不会引起 *unsatisfiable error*。在下载没有指定版本的包时，包版本高的优先。
+* *strict*：如果 ***高优先级通道*** 没有找到对应库便会报错。在下载没有指定版本的包时，通道优先级高的优先。
+
+```shell
+conda config --set channel_priority strict
+conda config --set channel_priority flexible
+```
+
+#### ⚙️ 其他通道配置
+
+* *show_channel_urls*：控制着**Conda**是否在执行操作（如搜索、安装或更新包）时显示通道的`URL`。
+* *channel_alias*：通道别名，**Conda**会先在 *channels* 与 *custom_channels* 中进行匹配，如果没找到相对应的完整`URL`，则会根据 *channel_alias* 进行补全，其默认值如下：
+
+    ```shell
+    conda config --describe channel_alias
+    
+    # # Result:
+    # # channel_alias (str)
+    # #   The prepended url location to associate with channel names.
+    # #   
+    # # channel_alias: https://conda.anaconda.org
+    
+    conda install GDAL -c conda-forge
+    
+    # # Result:
+    # # Equals toCondainstall GDAL -c 
+    # #	https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/conda-forge
+    ```
+
+#### 📄 `.condarc`示例配置
+
+```yaml
+channels:
+  - defaults
+  - conda-forge
+
+show_channel_urls: true
+
+# Conda-forge recommended
+channel_priority: strict
+
+default_channels:
+  - http://mirrors.aliyun.com/anaconda/pkgs/main
+  - http://mirrors.aliyun.com/anaconda/pkgs/r
+  - http://mirrors.aliyun.com/anaconda/pkgs/msys2
+
+custom_channels:
+  conda-forge: http://mirrors.aliyun.com/anaconda/cloud
+  msys2: http://mirrors.aliyun.com/anaconda/cloud
+  bioconda: http://mirrors.aliyun.com/anaconda/cloud
+  menpo: http://mirrors.aliyun.com/anaconda/cloud
+  pytorch: http://mirrors.aliyun.com/anaconda/cloud
+  simpleitk: http://mirrors.aliyun.com/anaconda/cloud
+```
+
+### 5. 缓存相关
+
+#### 🗑️ `conda clean`命令
+
+| 参数                                                         | 说明                                                         |
+| ------------------------------------------------------------ | ------------------------------------------------------------ |
+| *`-i`、<br/>`--index-cache`*                                 | 删除索引缓存                                                 |
+| *`-t`、`--tarballs`*                                         | 删除缓存的软件包压缩包                                       |
+| *`-a`、`--all`*                                              | 删除索引缓存、锁定文件、未使用的缓存软件包、压缩包和日志文件 |
+| *`-p`、<br/>`--packages`*                                    | 从可写软件包缓存中删除**未使用**的软件包（<span style='color:cyan'>注意！此模式不会检查使用符号链接返回软件包缓存安装的软件包</span>） |
+| *`-f`、<br/><span style='white-space: nowrap'>`--force-pkgs-dirs`</span>* | 删除**所有可写**的软件包缓存，**此选项未包含在`--all`中**（<span style='color:cyan'>注意！此模式将破坏使用符号链接返回软件包缓存安装软件包的环境</span>） |
+
+#### 📂 设置包缓存文件夹
+我们可以使用`conda config`为 *pkg_dirs* 添加包缓存目录。
+
+```shell
+conda config --add pkgs_dirs [package_cache_path]
+```
+
+我们分别使用`config info`与`--describe`来查看该配置。可以发现**Conda**自带包缓存的文件夹。
+
+```shell
+conda info
+
+# # Result:
+# # package cache : D:\Software\Anaconda\pkgs
+# #                 C:\Users\lzz\.conda\pkgs
+# # 				C:\Users\lzz\AppData\Local\conda\conda\pkgs
+
+
+conda config --describe pkgs_dirs
+
+# # Result:
+# # pkgs_dirs (sequence: primitive)
+# # pkgs_dirs: []
+```
+
+我们可以使用`conda clean`清空 *pkgs_dirs* 里面的包缓存。
+
+```shell
+conda clean --f
+conda clean --force-pkgs-dirs
+```
+
+## 管理环境
+
+### 1. 查询环境
+
+我们可以通过`env`或者`info`指令查看 *conda environments* 。
+
+```shell
+# Next three order equals ot each other
+conda env list
+conda info -e
+conda info --envs
+
+# # Result:
+# # conda environments:
+# # base                     D:\Software\Anaconda
+# # geo                      D:\Software\Anaconda\envs\geo
+```
+
+### 2. 环境管理
+
+#### 🆕 创建环境
+我们可以`create`指令创建一个全新的Python虚拟环境：
+
+```shell
+conda create [env_name]
+conda create [env_name] [python] [packages]
+
+# Example: create env with specifying python and packages
+conda create geo python=3.8 matplotlib plot
+```
+
+也可以根据`environment.yaml`来还原一个环境：
+
+```shell
+conda env create --file [env_name].yml
+
+# Example: create env by env.yaml
+conda env create --file environment.yml
+```
+
+#### 🗑️ 删除环境
+`remove`指令可以用于删除环境，也可以用于删除指定环境中的包：
+
+```shell
+# Delete specified env and all packages in it
+conda remove --name [env_name] --all
+
+# Delete specified package in env
+conda remove --name [env_name] [package_names]
+```
+
+#### 💾 导出环境配置
+`env`指令用于环境的导入导出，注意`env.yml`文件中已有虚拟环境名称：
+
+```shell
+# Get env.yml
+conda env export --name [env_name] > [env_name].yml
+
+# Create env by env.yml
+conda env create --file [env_name].yml
+
+# Example: export and create by env.yml
+conda env export --name geo > env.yml
+conda env create --file env.yml
+```
+
+#### 🚀 使用环境
+
+```shell
+conda activate [env_name]
+
+# Next two order equals to each other
+conda activate
+conda deactivate
+```
+
+### 3. 包管理
+
+#### 📄 查询包
+**Conda**查询包有两个指令，一个是`list`，其用于查询已安装的包；
+
+```shell
+# For all environments
+conda list
+
+conda list --name [env_name]
+
+# # Result: 
+# # packages in environment at D:\Software\Anaconda\envs\geo:
+# # Name                    Version                   Build  Channel
+# # ca-certificates           2024.7.2             haa95532_0
+# # libffi                    3.4.4                hd77b12b_1
+
+
+# Special attributes
+conda list --explicit --name [env_name]
+conda list --show-channel-urls --name [env_name]
+```
+
+`list`还有以下参数可选，用于查看包安装的详细信息：
+
+| 参数                    | 说明                       |
+| ----------------------- | -------------------------- |
+| *`--explicit`*          | 在输出时显示包的确切版本号 |
+| *`--show-channel-urls`* | 在输出时显示包的来源`URL`  |
+
+另一个是`search`，其用于在 *channels* 中查询指定包。请注意`conda search`还有个查询电脑上Python环境的功能。
+
+```shell
+conda search [package_name]
+
+# Fuzzy search
+conda search [package_name]*
+
+conda search [package_name] --channel [channel_name]
+
+# Special
+conda search [package_name] --info
+
+# # Result:
+# # gdal 3.6.2 py39hf6e6a5b_2
+# # -------------------------
+# # file name   : gdal-3.6.2-py39hf6e6a5b_2.conda
+# # name        : gdal
+# # version     : 3.6.2
+# # build       : py39hf6e6a5b_2
+# # build number: 2
+# # size        : 1.8 MB
+# # url         : [url]
+# # dependencies: [dependencies]
+```
+
+`search`还有以下参数可选，用于更好的查询包：
+
+| 参数          | 说明                   |
+| ------------- | ---------------------- |
+| *`--channel`* | 指定查询的通道         |
+| *`--limit`*   | 限定查询结果显示个数   |
+| *`--info`*    | 显示查询结果的详细信息 |
+
+#### 📥 安装包
+我们使用`conda install`安装包，我们可以在安装的时候指定包的版本、查找的<u>*channel*</u> 。有些包的下载过程中需要我们在命令行输入`Y`，`--yes`可以帮我们自动输入。
+
+```shell
+conda install [package_name]
+
+conda install [package_name] --name [env_name]
+
+# Specified attributes
+conda install [package_name]=[version]
+conda install [package_name] --channel [channel_name]
+
+# Auto check yes
+conda install [package_name] --yes
+```
+
+这里还需要补充在使用时需要注意的几个参数：
+
+| 参数                                       | 说明                           |
+| ------------------------------------------ | ------------------------------ |
+| *`--force-reinstall`*                      | 确保请求安装的包卸载并重新安装 |
+| *`--freeze-installed`、`--no-update-deps`* | 不要更新或更改已安装的依赖项   |
+
+还需要注意的一点是：**Conda**只支持在官方通道和第三方社区通道安装包，如果要安装`.wheel`格式的包，请使用`pip`安装，这时候需要注意之前提到的环境污染问题。
+
+#### 🗑️ 卸载包
+我们使用`conda uninstall`卸载包，需要注意`conda uninstall`默认<span style='color:cyan'>同时删除包的依赖</span>，<u>如果使用`--force`，则不会删除其依赖</u>。
+
+```shell
+conda uninstall [package_name]
+
+conda uninstall [package_name] --name [env_name]
+
+# Auto check yes
+conda uninstall [package_name] --yes
+
+# Maybe go into broken
+conda uninstall [package_name] --force
+conda uninstall [package_name] --force-remove
+```
+
+我们可以使用`conda uninstall --help`查看**Conda**对`--force`的描述。不要轻易使用`--force`，<u>这会使我们的环境变得破碎不稳定</u>。
+
+```shell
+# # --force-remove, --force
+# # 	Forces removal of a package without removing packages that depend on it. 
+# # 	Using this option will usually leave your environment in a broken and 
+# #     						inconsistent state.
+```
+
+#### ♻️ 更新包
+我们使用如下指令更新指定包到最新版本，如果要更新到指定版本，请使用功能更强大的`conda install`。
+
+```shell
+conda update [package_name] --name [env_name]
+```

--- a/source/_posts/control-compute.md
+++ b/source/_posts/control-compute.md
@@ -1,0 +1,966 @@
+---
+title: Python笔记：控制与运算
+date: 2024-10-14 18:45:50
+tags:
+  - python
+  - tutorial
+categories:
+  - 笔记 
+---
+
+> 这里我只是简单介绍一下Python控制与运算的一些常用内容，详细内容请参考：[Python 3.13.0 文档](https://docs.python.org/zh-cn/3/) 。
+
+## 运算
+
+Python提供了多种运算符来支持丰富的表达式写法，这些算术运算中的**大部分**可以通过自定义类中的**魔术方法**来修改实现方式，Python运算符大致可以分为如下几类：
+
+### 1. 算术运算符
+Python支持如下算术运算：
+
+| 常用算术运算符                  | 幂运算符                                   | 整除运算符                                |
+| --------------------------- | ------------------------------------------ | ----------------------------------------- |
+| `+` 、`-` 、`*` 、`/` 、`%` | <span style='color:cyan'>`**` </span> | <span style='color:cyan'>`//`</span> |
+
+### 2. 赋值运算符
+Python的赋值运算符有：`=` 、**`[operator]=`** 、<span style='color:cyan'>`:=`（海象运算符）</span> 。
+
+**海象运算符** | `Walrus Operator` 是`Python 3.8`中引入的一种新的运算符，正式名称为 **赋值表达式** | `Assignment Expression` ，但它更广为人知的名称是海象运算符，因为它的符号`:=`看上去像是海象。这个运算符允许我们在表达式内部进行赋值。
+
+```python
+x = 0
+if (x := 10) > 5:  
+    print("x is greater than 5")
+else:
+    print("x is", x)
+```
+
+还需要注意的是，Python的`=`运算符的使用方法与`Golang`类似。Python允许我们用一个赋值运算符为多个变量赋值。
+
+```python
+def test_func():
+    return 1,2
+
+x=1
+x, y=1, 2
+x, y=test_func()
+x, y=y, x
+```
+### 3. 身份运算符
+
+Python的身份运算符有：`is`、`not is`。
+
+```python
+class Test:
+    def __init__(self, value):
+        self.value = value
+
+        def __eq__(self, other):
+            if other.value == self.value:
+                return True
+            else:
+                return False
+
+        def __hash__(self):
+            return hash(self.value)
+
+test1=Test(10)
+test2=Test(10)
+
+print(test1==test2)                         # True
+print(test1.__hash__()==test2.__hash__())   # True
+
+print(id(test1)==id(test2))                 # False
+print(test1 is test2)                       # False
+```
+
+需要注意的是，`is`运算符**不对应**任何<u>魔术方法</u> ，它是直接比较内存地址的。
+
+### 4. 解构运算符
+
+`*`、`**`是Python中的解构运算符，其中`*`用于解构**数组**，`**`用于解构**字典**。
+
+我们常见这样的函数头`def test_func(*args, **kwargs):`，这里的`*args`其实可以看做用解构后的数组`args`去接收<u>未指明形参的数据</u>，而`**kwargs`可以看作用解构后的字典`kwargs`去接受<u>指明了形参的数据</u>。
+
+```python
+args=[1,2,3]
+kwargs={'attr1': 4, 'attr2': 5}
+
+def test_func(*args, **kwargs):
+    print(args)
+    print(kwargs)
+
+test_func(*args, **kwargs)
+```
+
+同`JavaScript`类似，Python的解构运算符不止用于接收函数参数，也可以用于数组与字典的扩展或融合</u>。需要注意的是，解构后的数据不再是对象，而是一串特殊的输出序列。解构数组的输出序列可看作`for i in arr`，解构字典的输出序列可以看作`for k, v in dic`。 
+
+```python
+arr = [1, 2, 3]
+dic = {'attr1': 4, 'attr2': 5}
+
+new_arr = [*arr,4,5,6]
+new_dic = {**dic, 'add1':4, 'add2':5}
+
+print(new_arr)
+print(new_dic)
+
+print(*new_arr)		# Equals: print(1,2,3,4,5,6)
+print(**new_dic)	# Error
+```
+
+`*`除了可以解构数组外，还支持解构实现了`__iter__()`魔术方法的可遍历对象；而`**`则较为特殊，它并不支持解构实现了`__getitem__`、`__setitem__`、`__iter__`等魔术方法的类字典对象。
+
+### 5. 其他运算符
+
+| 类别           | 成员                                        |
+| -------------- | ------------------------------------------- |
+| **位运算符**   | `&`（与）、`\|`（或）、`^`（或）、`~`（非） |
+| **比较运算符** | `==` 、`!==` 、`>` 、`>=` 、`<` 、`<=`      |
+| **逻辑运算符** | `and` 、`or` 、`not`                        |
+| **成员运算符** | `in` 、`not in`                             |
+
+## 控制
+
+### 1. 条件控制
+
+Python的条件控制方式有两种：
+
+* **`if-else` 语句**
+
+    当只有两个分支时使用`if-else`：
+
+    ```python
+    n=10
+    if n>10:
+        pass
+    else:
+        pass
+    ```
+
+    当有多个分支时使用`if-elif-else`：
+
+    ```python
+    n=10
+    if n>10:
+        pass
+    elif n<0:
+        pass
+    else:
+        pass
+    ```
+
+    在其他语言中我们可以使用<span style='color:cyan'>**三目运算符**</span>来简化有关赋值的条件控制结构，而在Python中我们可以使用`if else`来实现相同的效果：
+
+    ```python
+    a=10
+    b= a+5 if a>10 else a-5
+    
+    max=lambda a, b: a if a>b else b
+    print(max(3,4))		# 4
+    ```
+
+* **`match-case` 语句**
+
+    在`Python 3.10`及其以后版本，我们可以`match-case`简化 `if-elif-else` 语句段，类似于其他语言中的`switch-case`。
+
+    `match-case`在多分支的实现上于其他方法有所不同：
+
+    * `match-case`中一旦某个模式匹配成功，后续`case`将不再进行匹配，不需要像其他语言那样使用`break`推出匹配；
+    * `match-case`中`_`用于匹配任何值，相当于其他语言的`default`；
+
+    ```python
+    n=10
+    match n:
+        case n<10:
+            pass
+        case n==10:
+            pass		
+        case n>=10:
+            pass		# Wont enter this case
+        case _:
+            pass
+    ```
+
+
+### 2. 循环控制
+
+Python的循环控制方式有两种：
+
+*  **`while` 语句**
+
+    `while`是循环控制的一种形式，需要注意的是Python中有`while-else`这种**独特**的语法。一般`while`循环如下：
+
+    ```python
+    acc=0
+    while (acc:=acc+1) <= 5:
+        print(acc, end=' ')
+    
+    # 1 2 3 4 5
+    ```
+
+    我们可以使用`break`跳出当前循环，使用`else`声明循环体正常结束后的任务。当我们使用`break`跳出循环体时，Python不会执行`else`之后的内容。这种`while-else`可以简化其他编程语言在使用`break`推出前更改`flag`值的行为。
+
+    ```python
+    acc = 0
+    while (acc := acc + 1) <= 10:
+        if acc == 5:
+            break
+            print(acc, end=' ')
+        else:
+            print('exit')
+    
+    # 1 2 3 4 
+    ```
+
+
+* **`for` 语句**
+
+    `for`循环控制的另一种形式，需要注意的是Python中有`for-else`这种**独特**的语法。一般`for-else`循环如下：
+
+    ```python
+    for i in range(1, 5):
+    	print(i, end=" ")
+    else:
+    	print('exit')
+    
+    # 1 2 3 4 exit
+    ```
+
+    如果要使得我们的类支持`for-in`遍历的话需要支持`__iter__`魔术方法。
+
+    一般来说我们可以直接使用`for item in iterable:`循环遍历可遍历序列，我们也可以遍历`range(st, ed, foot)`生成的指定首尾和步长的可遍历序列。以下简单说明下`range`的使用：
+
+    | 使用方式                                                     | 说明                                                         |
+    | ------------------------------------------------------------ | ------------------------------------------------------------ |
+    | **`range(ed)`**                                              | 当只有一个参数时，`range`默认`st=1`。需要注意的是Python并不支持带有默认值的参数写前面，故我们如果要自己手写一个`range`的话需要使用`*args`来接受参数 |
+    | **`range(st, ed)`**                                          | 当只指定了起始于结束的参数时，`range`默认`foot=1`            |
+    | **<span style='white-space: nowrap'>`range(st, ed, foot)`</span>** | `foot`可以为正数也可以为负数，但不能为0，注意`range`的退出条件 |
+
+    ```python
+    def print_range(range):
+        print('[', end='')
+        for i in range:
+            print(i, end=', ')
+        print(']')
+    
+    args=[2,10,2]
+    for i in range(1,4):
+        print_range(range(*args[:i]))
+    ```
+
+    `for`除了支持`break`，还支持使用`continue`来控制循环体。
+
+    ```python
+    for i in range(1, 10):
+        if i==5:
+            continue
+        if i==8:
+            break
+        print(i, end=' ')
+    
+    # 1 2 3 4 6 7 
+    ```
+
+    当我们不需要使用每次循环的`i`时，我们可以使用`_`占位符来代替`i`。
+
+    ```python
+    for _ in range(10):
+        print('Loop')
+    ```
+
+
+### 3. 异常控制
+
+Python的异常都是从`BaseException`派生而来，`BaseException`的派生类可以参考：[内置异常 — Python 3.14.0a0 文档](https://docs.python.org/zh-cn/3.14/library/exceptions.html#BaseException)。 *<u>Python 的异常常随则版本更新而变化</u>* ，在Python中使用异常类时请参考对应Python版本的`BaseException`文档。以下列出来`BaseException`的第一层派生情况：
+
+* <span style='color:cyan'>**`Exception`**</span>：所有内置的非系统退出类异常都派生自此类。 所有用户自定义异常也应当派生自此类；
+
+* **`SystemExit`**：该异常由 [`sys.exit()`](https://docs.python.org/zh-cn/3.14/library/sys.html#sys.exit) 函数引发；
+* **`KeyboardInterrupt`**：当用户按下 `Ctrl+C` 、`Del` 时被触发；
+* **`BaseExceptionGroup`**： 用于成组处理异常（<span style='color:pink'>`python 3.11` 加入</span>）；
+
+    下列异常是在有必要引发多个不相关联的异常时使用的。 它们是异常层级结构的一部分因此它们可以像所有其他异常一样通过[`except`](https://docs.python.org/zh-cn/3.14/reference/compound_stmts.html#except)来处理。 此外，它们还可被[`except*`](https://docs.python.org/zh-cn/3.14/reference/compound_stmts.html#except-star)所识别，此语法将基于所包含异常的类型来匹配其子分组。
+
+    ```python
+    try:
+        raise ExceptionGroup("eg",[
+            ValueError(1), 
+            TypeError(2), 
+            OSError(3), 
+            OSError(4)
+        ])
+        except* TypeError as e:
+            print(f'caught {type(e)} with nested {e.exceptions}')
+    #   except* OSError as e:
+    #    	print(f'caught {type(e)} with nested {e.exceptions}')
+    ```
+
+* **`GeneratorExit`**：用于生成器推出错误；
+
+我们可以通过继承已有的异常类来创建我们的异常类。以下是编写异常类的最佳实践：
+* **创建普通异常类**：继承`Exception`或者它的子类，重写父类方法，添加其他方法；
+* **为模板创建异常类**：一个模块有可能抛出多种不同的异常时，一种通常的做法是为这个包建立一个基础异常类，然后基于这个基础类为不同的错误情况创建不同的子类；
+
+Python的异常控制主要由两个板块构成：<u>处理异常</u>、<u>抛出异常</u>。
+
+#### 🛠️ 异常处理
+
+> `try-except`是Python异常处理的常用模板，此外`with`语句也与异常处理有关。
+
+`try-except` 来捕获并处理异常，在 Python 在 `python 3.11` 之后引入了 `BaseExceptionGroup` ，为了处理异常集我们可以使用 `except*` 来捕获异常。由于支持 `except*` 与异常集的 Python 版本较新，在这里我只列出普通的 `try-except` 捕获异常的基本模板，如果需要在较新 Python 版本中使用异常集请查看相关文档：
+
+```python
+try:
+    raise Exception('error')
+except Exception as err:		# use err catch Exception ins
+    pass				# run when error catched
+else:
+    pass				# run when error uncatched
+finally:
+    pass
+```
+
+`with` 语句用于包裹执行代码段，以便于管理资源，如文件操作、数据库连接、网络连接等。它确保了资源的正确使用和释放，即使在代码执行过程中发生了异常。我们使用 `with` 获取的类型实例实现了魔术方法 `__enter__` 与 `__exit__` 。`__enter__` 方法用于返回可供 `with` 代码段使用的实例对象，当我们在代码段中抛出了异常后， `__exit__` 实现了对该异常的处理代码，因此不需要我们在使用时进行处理。
+
+```python
+class ManagedResource:
+    def __enter__(self):
+        print("Enter the context")
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        print("Exit the context")
+        if exc_type:
+            print(f"Exception: {exc_type, exc_value}")
+
+with ManagedResource() as resource:
+    print("Inside 'with' statement")
+    raise ValueError("Oops!")
+```
+
+#### ⚠️ 抛出异常
+
+Python的`raise`语句类似于其他语言中的`throw`语句，用于抛出新建的异常。
+
+```python
+raise Exception('new error')
+```
+
+Python的`assert`语句用于断言某个条件是真的。如果条件为真，则程序继续执行；如果条件为假，则程序抛出`AssertionError`异常。
+
+```python
+try:
+    assert 2+2==3, "AssertionError ins"
+    # assert template
+    # assert <bool expression>, <assert string>
+
+except Exception as err:
+    print(type(err))
+    print(repr(err))
+
+    # <class 'AssertionError'>
+    # AssertionError('AssertionError ins')
+```
+
+需要注意的是，Python的断言常用于开发中进行调试。我们可以在使用Python进行解释执行的时候将全部`assert`语句进行移除，因此在代码中我们不应使用`assert`进行编写业务逻辑。
+
+## 函数
+
+### 1. 命名空间
+
+命名空间是存储变量名称和值的映射表，而作用域是Python程序可以直接访问命名空间的正文区域。在Python文档中并没有 **作用域** | `scope` 相关的词条，作用域只是根据命名空间划分的正文片段。Python的命名空间有以下类型：
+
+* **局部命名空间**：在<u>函数中定义的变量</u>将存储在对应函数的局部命名空间中，注意<span style='color:cyan'>局部命名空间可以嵌套</span>；
+* **全局命名空间**：在<u>模块中定义的变量</u>将存储在对应模块的全局命名空间中；
+    我们有`name1.py`文件如下：
+
+    ```python
+    name="test"
+    ```
+
+    我们在其它文件中调用`name1.py`中的变量或者函数时可以使用以下两种调用方式：
+
+    ```python
+    import name1
+    from name1 import *
+    
+    print(name1.name)   # test
+    print(name)         # test
+    name='inside'
+    print(name1.name)   # test
+    print(name)			# inside
+    ```
+
+    需要注意的是第二条导入语句`from name1 import *`只是允许我们像使用本模块的全局命名空间中的变量那样使用`name1.py`中的变量，不是将`name`移动到本模块的全局命名空间中。这里我们使用`name='inside'`事实上是在本模块的全局命名空间中声明了该变量。
+* **内置命名空间**：Python解释器提供的内置变量存储在内置命名空间中；
+    想要了解Python的内置变量可以查询Python文档，或者使用 `dir()` 查询。
+
+    ```python
+    import builtins
+    
+    for key_name in dir(builtins):
+     print(key_name, type(getattr(builtins, key_name)))
+    ```
+
+
+下面我们详细了解一下命名空间的变量使用规范：
+
+* **引用变量**：当我们引用一个变量时，Python会按照由局部命名空间到内置命名空间的顺序搜索相应变量；
+
+* **管理变量**：当我们在内部作用域想要<u>**修改、删除、声明**</u>外部作用域的变量时，需要使用`global`、`nonlocal`关键字声明对应变量；
+
+    需要注意的是，在多层函数嵌套中`global`用于引用当前模块的<span style='color:cyan'>全局作用域</span>对应命名空间中的变量，`nonlocal`用于引用上一级<span style='color:cyan'>函数作用域</span>对应命名空间中的变量。
+
+    当然，`global`与`nonlocal`关键字不只用于引用相应位置的变量，也可以用于声明相应位置的变量。 最后需要注意的是，`global`、`nonlocal`不能引用或者管理其他模块对应的全局命名空间中的变量。
+
+    ```python
+    x, y=1,1
+    
+    def test():
+        global x
+        global z
+        global delete
+        x+=1
+        y=10
+        z=100
+        delete=1000
+        del delete
+    
+        def closure():
+            nonlocal y
+            y+=1
+            print(f"nonlocal y: {y}")
+    
+        return closure
+    
+    test()()
+    print(f"global x: {x}")
+    print(f"global y: {y}")
+    print(f"global z: {z}")
+    print(f"global delete: {delete}")
+    
+    # # Result:
+    # # nonlocal y: 11
+    # # global x: 2
+    # # global y: 1
+    # # global z: 100
+    # # NameError: name 'delete' is not defined
+    ```
+
+
+### 2. 导入系统
+
+导入系统是Python的核心部分，它允许我们将代码组织成模块和包，从而实现代码的重用和组织。关于导入系统我们可以参考Python文档：[导入系统 — Python 3.13.0 文档](https://docs.python.org/zh-cn/3/reference/import.html)。
+
+在`JavaScript`中，我们可以使用`import`导入文件夹或者文件。在Python中我们可以使用`import`关键字导入模块、包或者模块、包中的变量，以下是几种导入语句：
+
+* **`import module`**：导入对应模块、包，创建名为`module`的实例对象；
+
+* **`from module import module`**：导入模块、包中的对应子模块、包；
+
+* **`from module import var`**：导入模块、包中对应的变量；
+
+    需要注意的是在这里说的变量是广义上的变量，即Python的类的实例类型。例如，函数便是`function`类的实例对象，类便是元类`type`的实例对象。
+
+* **`from module import *`**：导入模块、包中所有可导出的变量；
+
+    我们可以在模块或者包的`__init__.py`中声明`__all__`魔法变量，指定能被`from module import *` 导出的变量名。需要注意的是`__all__`只适用于该语句，`import module`和`from module import var`均可访问该变量。
+
+    ```python
+    # module_1.py
+    
+    __all__=['a', 'b']
+    a,b,c=1,2,3
+    ```
+
+    ```python
+    # test.py
+    
+    import module_1
+    from module_1 import *
+    
+    print(module_1.a)	# 1
+    print(a)		# 1
+    
+    print(module_1.c)	# 3
+    print(c)		# NameError: name 'c' is not defined
+    ```
+
+在Python中我们使用`import`关键字导入模块或者包时，不需要考虑文件路径问题。Python解释器会在运行时在`sys.path`中查找相应的模块或者包。值得一提的是该查找过程也存在优先级关系，在`sys.path`中靠前的文件夹下的模块和包具有更高的优先级。
+
+需要注意的是，当我们在`PyCharm`中使用图形化界面运行Python文件时，IDE会为我们添加**当前文件夹**和**项目文件夹**到`sys.path`中。
+
+```python
+import sys
+
+for path in sys.path:
+    print(path)
+    
+# # Result:
+# # === IDE INSERT ===
+# # D:\Code\Python\Science\learn\folder\folder
+# # D:\Code\Python\Science\learn
+
+# # === ORIGIN ===
+# # D:\Software\Anaconda\envs\geo\python39.zip
+# # D:\Software\Anaconda\envs\geo\DLLs
+# # D:\Software\Anaconda\envs\geo\lib
+# # D:\Software\Anaconda\envs\geo
+# # D:\Software\Anaconda\envs\geo\lib\site-packages
+```
+
+我们在前面介绍了如何利用导入对象的属性来区别模块、常规包与命名空间包。我们在这里简单介绍一下模块对象的部分属性：
+
+| 名称                                                      | 说明                                                         |
+| --------------------------------------------------------- | ------------------------------------------------------------ |
+| **`__name__`**                                            | 该属性必须被设为模块的完整限定名称，其用来在导入系统中作为模块标识； |
+| <span style='white-space: nowrap'>**`__loader__`**</span> | 该属性是导入系统在导入模块时使用的加载器对象（<span style='color:pink'>`Python 3.12` 后该属性仍可使用，但推荐使用 `__spec__.loader` 属性，`Python 3.14` 后该属性将被废弃</span>）； |
+| **`__spec__`**                                            | 该属性是导入模块时要使用的模块规格说明；                     |
+| **`__path__`**                                            | 如果模块是包，则`__path__`是可迭代的字符串序列。如果模块不是包，则`__path__`属性不存在； |
+
+需要注意的是Python除了有`regular packages`还有`namespace packages`这种特殊的包导入模式。下面我们依次介绍这三种导入模式：
+
+* **模块**：Python将单个Python文件称为模块；
+
+* **常规包**：Python将包含`__init__.py`文件的文件夹或者压缩文件夹称为常规包；
+
+    Python 中的`__init__.py`文件更像是`JavaScript`中的`index.js`或者`index.ts`文件，用于导出同级目录下的其他模块或者包。子包可以是常规包，也可以是命名空间包。
+
+    我们可以使用`__path__`属性来确定导入的是模块还是包。
+
+    ```python
+    import module_1
+    import package_1
+    import namespace_package_1
+    
+    print(module_1.__path__)
+    print(package_1.__path__)
+    print(namespace_package_1.__path__)
+    
+    # # Result:
+    # # AttributeError: module 'module_1' has no attribute '__path__'
+    # # ['D:\\Code\\Python\\Science\\learn\\package_1']
+    # # _NamespacePath([
+    # # 	'D:\\Code\\Python\\Science\\learn\\namespace_package_1', 
+    # # 	'D:\\Code\\Python\\Science\\learn\\namespace_package_1'
+    # # ])
+    ```
+
+    当我们在编写同一个包的不同模块时，想要在一个模块中导入另一个模块，可以采用相对导入方法。
+
+    ```
+    mypackage/
+    │
+    ├──subpackage1/
+    │   ├── __init__.py
+    │   ├── module0.py
+    │   └── module1.py
+    │
+    ├── subpackage2/
+    │   ├── __init__.py
+    │   └── module2.py
+    │
+    └── __init__.py
+    ```
+
+    ```python
+    # mypackage/subpackage1/module0.py
+    
+    from . import module1
+    from .. import subpackage2
+    from ..subpackage2 import module2
+    ```
+
+* **命名空间包**：Python 将没有 `__init__.py` 的文件夹称为命名空间包（<span style='color:pink'>`Python 3.3` 后引入了命名空间包</span>）；
+
+    Python的命名空间包允许我们将一个包跨多个目录拆分。当我们在不同文件夹下有相同名称的命名空间包，这些命名空间包共享一个命名空间。例如当第三方包中有名为`namespace_package_1`的命名空间包，我们在自己的项目文件夹下拓展了改包中的子包或这子模块，我们可以使用<span style='color:cyan'>相同的导入方式</span>导入拓展包与原始包，保证代码的可读性。
+
+    ```python
+    from namespace_package_1 import origin
+    from namespace_packges_1 import new
+    ```
+
+    此外我们还可以在拓展包中相对导入原始包：
+
+    ```python
+    from . import origin
+    ```
+
+    关于命名空间包的使用实践可以参考这篇文章：[关于namespace packages - 知乎](https://zhuanlan.zhihu.com/p/379449893#:~:text=进入命名空间包的神奇)。
+
+Python文档中推荐使用`importlib`动态导入模块，`importlib`模块是Python的标准库模块。使用`importlib`，我们可以动态地导入模块，这意味着可以在运行时根据需要导入模块，而不是在代码的开头静态地导入它们。关于`importlib`我们可以参考Python文档：[importlib — Python 3.13.0 文档](https://docs.python.org/zh-cn/3/library/importlib.html#)。我们在这里简单介绍一下`importlib`的部分用法：
+
+* **`importlib.import_module(name, package=None)`**：  参数 *name* 指定了以绝对或相对导入方式导入什么模块。如果采用相对导入的方式，那么 *package* 必须设置为那个包名；
+
+    ```python
+    import importlib
+    
+    module_1=importlib.import_module('pkg.mod')
+    module_2=importlib.import_module('..mod', 'pkg.subpkg')
+    ```
+
+* **`importlib.reload(module)`**：重新加载之前导入的 *module*。 那个参数必须是一个之前已经成功导入的模块对象。该方法常用于调试和开发中，因为它允许我们在修改模块代码后重新加载它们而不需要重启程序。这里不继续介绍该方法的使用细节，请使用时翻阅文档；
+
+
+### 3. 函数与匿名函数
+
+Python可以使用`def`关键字定义一个函数对象，以下是一个较为完善的函数模板：
+
+```python
+def test_func(a:int, b:str, *args, **kwargs):
+    """
+    Write function docs here
+
+    :param a: Description of param 'a'
+    :type a: int
+    :param b: Description of param 'b'
+    :type b: str
+    :param args: Description of param 'args'
+    :param kwargs: Description of param 'kwargs'
+    :return: Description of return
+    :rtype: None
+    """
+    print(a, b)
+    print(args)
+    print(kwargs)
+    return
+
+rt_data=test_func(1,'2',3,c=1,d=2,e=3)
+print(rt_data)
+
+# # Result:
+# # 1 2
+# # (3,)
+# # {'c': 1, 'd': 2, 'e': 3}
+# # None
+```
+
+我们从以下方面了解一下函数：
+
+* **参数**
+
+    函数在调用的时候可以接收数值作为参数值，也可以接收键值对作为参数值。我们可以用`*args`接收哪些未在函数头中指明形参的数值数组，其中接收到的数值序列是以元组的形式存储的；此外我们还可以使用`**kwargs`接收未在函数头中指明的键值对，其中接收到的键值对序列是以字典的形式存储的。**需要注意的有**：
+
+    1. 在调用函数时，参数格式需要遵守<span style='color:cyan'>先数值后键值对的规范，否则程序会报错</span>。
+
+        我们在函数头中指明了的参数名，在参考模板中为`a`、`b`实际上可以使用数值或者键值对这两种方式提供，但如果我们的函数头的参数定义类似上述模板，则只能使用数值的方式提供。因为，指明参数必须在未指明参数之前，数值参数必须在键值对参数之前。
+
+    2. Python不支持<span style='color:cyan'>函数重载</span>，这意味着我们的函数如果需要有多个处理模式，可以设置`mode`参数进行区分，然后再根据对应模式处理每次调用的不定长参数序列`args`、`kwargs`。 我们也可以通过设置形参默认参数与`isinstance(ins, type)`来实现函数重载的类似效果。
+
+        ```python
+        def test_func1(mode, *args, **kwargs):
+            pass
+        
+        def test_func2(a, b=None):
+            if isinstance(a, int) and b is None:
+                return a
+            elif isinstance(a, int) and isinstance(b, int):
+                return a + b
+            else:
+                raise TypeError("Unsupported types")
+        ```
+
+    3. 在`Python 3.8`中新增了一个函数形参语法，我们可以用`/`、`*`来分割函数形参的数值部分与键值对部分。在`/`左边的形参必须以数值方式提供，在`*`右边的形参必须以键值对方式提供，两者中的形参既可以使用数值也可以使用键值对方式提供。但需要注意的是，调用时参数仍需满足先数值后键值对的形参提供方式。
+
+        ```python
+        def test_func(a, b, /, c, d, *, e, f):
+            pass
+        
+        test_func(1,2,3,d=4,e=5,f=6)
+        ```
+
+    在Python函数的学习中，我们还需要注意**参数传递**的细节。当我们传递的参数是<span style='color:cyan'>不可变数据类型</span>时，我们在函数体内修改参数的值不会影响到原对象，当我么传递的参数是<span style='color:cyan'>可变数据类型</span>时，我们在函数体内对参数进行修改会影响到原对象。关于可变数据类型与不可变数据类型请参考：
+
+    ```python
+    def test_func(a, b):
+        a=10
+        b.append(10)
+    
+    a, b=1, [1,2,3]
+    test_func(a, b)
+    print(a, b)		# 1 [1, 2, 3, 10]
+    ```
+
+
+* **返回值**
+
+    我们可以在函数头后边使用`->`声明函数的返回值类型，这个函数返回值类型声明不是必须的。
+
+    1. 当函数没有使用`return`返回返回值时，默认返回值是`None`。
+    2. Python支持像`Golang`那样返回多个返回值，我们可以配合Python中`=`的多变量赋值特性，简化代码。
+
+        ```python
+        def test_func():
+            return 1, 2
+        
+        x, y=test_func()
+        ```
+
+    Python的匿名函数的功能有限，我们可以使用`lambda`关键字来创建Python的匿名函数。以下是一个简单的匿名函数模板：
+
+    ```python
+    # # Template:
+    # # lambda <arguments>: <return>
+    func = lambda x: x+5
+    print(func(10)) 	# 15
+    
+    max = lambda x, y: x if x>=y else y
+    print(max(3, 4)) 	# 4
+    ```
+
+
+### 4. 装饰器
+
+装饰器是Python中一种非常强大的工具，它们允许我们在不修改原有函数代码的情况下，给函数添加新的功能。装饰器有以下两种类型：
+
+* **函数装饰器**
+
+    以下是一个函数装饰器的模板。需要注意的是装饰器实际上是Python的 <u>*语法糖*</u> ，我们完全可以不用使用`@decorator`的方式实现相同的功能。
+
+    ```python
+    def my_decorator(func):
+     def wrapper(x, y):
+         print(f"Before {func.__name__}, x: {x}, y: {y}")
+         result = func(x, y)
+         print(f"After {func.__name__}, result: {result}")
+         return result
+     return wrapper
+    
+    @my_decorator
+    def add(x, y):
+     return x + y
+    
+    # # Equals to next line
+    # # add=my_decorator(add)
+    ```
+
+    装饰器可以接收参数，这需要给装饰器外层再添加一层函数：
+
+    ```python
+    def repeat(num_times):
+     def decorator_repeat(func):
+         def wrapper(*args, **kwargs):
+             for _ in range(num_times):
+                 result = func(*args, **kwargs)
+             return result
+         return wrapper
+     return decorator_repeat
+    
+    @repeat(num_times=3)
+    def greet(name):
+     print(f"Hello {name}")
+    
+    greet("World")
+    
+    # # Equals to next two lines
+    # # my_decorator=repeat(num_times)
+    # # greet=my_decorator(greet)
+    ```
+
+
+* **类装饰器**
+
+    从`Python 3.4`开始，实现了`__call__`魔术方法的类也可以作为装饰器。
+
+    ```python
+    class MyDecorator:
+     def __call__(self, func):
+         def wrapper(x, y):
+             print(f"Before {func.__name__}, x: {x}, y: {y}")
+             result = func(x, y)
+             print(f"After {func.__name__}, result: {result}")
+             return result
+         return wrapper
+    
+    @MyDecorator()
+    def add(x, y):
+     return x + y
+    
+    print(add(2, 3))
+    ```
+
+
+### 5. 迭代器与生成器
+
+在Python中，**迭代器** | `Iterator` 和 **生成器** | `Generator` 是用于高效处理数据集合的两种机制。
+
+* **迭代器**
+
+    迭代器有两个基本的方法：
+
+    * `iter()`：调用该方法返回一个迭代器对象，此方法对应的魔术方法为`__iter__`。需要注意的是，对对象调用`iter()`返回的对象，不一定需要是对象本身，只需是一个迭代器对象即可；
+
+    * `next()`：调用该方法可以对迭代器对象进行迭代，迭代器对象需要实现`__next__`魔术方法。我们可以使用`StopIteration`异常来标记迭代完成，防止出现无限循环在`next()`方法中我们可以设置在完成指定循环次数后触发`StopIteration`异常来结束迭代；
+
+        ```python
+        class MyNumbers:
+          def __iter__(self):
+            self.a = 1
+            return self
+        
+          def __next__(self):
+            if self.a <= 20:
+              x = self.a
+              self.a += 1
+              return x
+            else:
+              raise StopIteration
+        
+        myclass = MyNumbers()
+        myiter = iter(myclass)
+        
+        for x in myiter:
+          print(x)
+        ```
+
+    需要注意的是<span style='color:cyan'>对于一个迭代器来说，生命周期内只能进行一轮迭代</span>，之后再调用`next()`便会引起`StopIteration`的异常。当我们多次使用`for item in list`遍历列表等序列时，实际上是为每一轮迭代生成了一个迭代器。
+
+
+* **生成器**
+
+    在Python中，使用了`yield`的函数被称为 **生成器** | `generator` 。生成器是一种特殊的迭代器，它使用`yield`语句来产生一系列值。每次迭代到`yield`语句时，它会暂停执行并保存当前的运行状态，然后返回值给调用者。当下次迭代时，它会从上次暂停的地方继续执行。
+
+    ```python
+    def my_generator(data):
+     for item in data:
+         yield item
+    
+    my_gen_1=my_generator([1,2,3,4,5])
+    for item in my_gen_1:
+     print(item)
+    
+    my_gen_2 = my_generator([5,4,3,2,1])
+    print(next(my_gen))
+    print(next(my_gen))
+    print(next(my_gen))
+    print(next(my_gen))
+    print(next(my_gen))
+    ```
+
+
+### 6. 内置方法
+
+Python的标准库为我们提供了一些内置方法，想要了解Python的内置方法有哪些可以查询Python文档：[内置函数 — Python 3.13.0 文档](https://docs.python.org/zh-cn/3/library/functions.html)。在这里我们只列出一部分常用的Python内置方法。
+
+#### 🔁 用于可迭代序列
+
+* **`all(iterable)`**：如果 *iterable* 的所有元素均为真值（或可迭代对象为空）则返回`True`。 等价于：
+
+    ```python
+    def all(iterable):
+        for element in iterable:
+            if not element:
+                return False
+        return True
+    ```
+
+* **`any(iterable)`**：如果 *iterable* 的任一元素为真值则返回`True`。 如果可迭代对象为空，返回`False`。 等价于：
+
+    ```python
+    def any(iterable):
+        for element in iterable:
+            if element:
+                return True
+        return False
+    ```
+
+* **`zip(*iterables, strict=False)`**：该方法返回元组的迭代器，其中第 *i* 个元组包含的是每个参数迭代器的第 *i* 个元素。默认情况下，`zip()`会在最短的参数迭代器迭代完成后停止（<span style='color:pink'>`Python 3.10` 后引入 `strict` 。当 `strict` 为 `True` 时，`zip()` 会检查 *iterable* 是否长度相等。</span>）：
+
+    ```python
+    l1=[1,2,3]
+    t1=(1,2,3,4,5)
+    z1=zip(l1, t1)
+    
+    print(z1)
+    for item in z1:
+        print(item)
+    
+    # # Result:
+    # # <zip object at 0x000001E0AA6EE900>
+    # # (1, 1)
+    # # (2, 2)
+    # # (3, 3)
+    ```
+
+* **`enumerate(iter, start=0)`**：返回一个枚举对象。我们可以通过设置`start`参数来控制<u>计数器开始值</u>：
+
+    ```python
+    l1=['a', 'b', 'c', 'd']
+    enum=enumerate(l1)
+    
+    print(enum)
+    for item in enum:
+        print(item)
+    
+    # # Result: 
+    # # <enumerate object at 0x0000013B7D0CE7C0>
+    # # (0, 'a')
+    # # (1, 'b')
+    # # (2, 'c')
+    # # (3, 'd')
+    ```
+
+#### 🧱用于实例对象
+
+* **`callable(obj)`**：判断 *obj* 是否为可调用类型实例（<span style='color:pink'>该方法在 `Python 3.0` 时被移除，然后在 `Python 3.2` 时被重新加入。</span>）；
+* <span style='color:cyan'>**`dir(obj)`**</span>：如果没有实参，则返回当前本地作用域中的名称列表。如果有实参，它会尝试返回该对象的<span style='color:cyan'>有效属性列表</span>；
+
+    ```python
+    print(dir())
+    
+    # # Result: 
+    # # [
+    # #     '__annotations__', 
+    # #    '__builtins__', 
+    # #    '__cached__', 
+    # #    '__doc__', 
+    # #     '__file__', 
+    # #     '__loader__', 
+    # #     '__name__', 
+    # #     '__package__', 
+    # #     '__spec__'
+    # # ]
+    ```
+
+* **`hasatter()`**：判断对象是否有对应属性。此方法是调用`getattr(object, name)`看是否有`AttributeError`异常来实现的；
+
+* **`getattr(object, name)`**
+    **`getattr(object, name, default)`**：获取对象的属性值。如果在调用时提供了`default`且没有该属性则返回`default`，如果在调用时没有提供`default`且没有该属性则会引起 `AttributeError`的异常；
+
+* **`setattr(object, name, value)`**：设置对象对应属性值；
+
+* **`delattr(obj, name)`**：删除对象的属性值。如果对象没有该属性则会引起`AttributeError`的异常；
+
+#### 🧪用于执行与测试
+
+我们在这里只简单介绍一下以下方法。关于 `breakpoint()` 、*globals* 、*locals* 等细节请参考Python文档。
+
+| 函数                                                         | 说明                                                         |
+| ------------------------------------------------------------ | ------------------------------------------------------------ |
+| **`breakpoint(*args, **kwargs)`**                            | 我们可以在代码中使用`breakpoint()`暂停程序                   |
+| **`eval(source, /, globals=None, locals=None)`**             | 该方法用于将字符串作为<u>Python 表达式</u>来执行，并返回表达式的值； |
+| **`exec(source, /, globals=None, locals=None, *, closure=None)`** | 该方法用于执行存储在字符串或对象中的<u>Python 代码</u>；     |
+
+#### 🆔 用于对象标识符
+
+| 函数            | 说明                                                         |
+| --------------- | ------------------------------------------------------------ |
+| **`id(obj)`**   | 返回对象的“标识值”。该值是一个整数，在此对象的生命周期中保证是唯一且恒定的。两个生命期不重叠的对象可能具有相同的`id()`值 |
+| **`hash(obj)`** | 返回该对象的哈希值。对于具有自定义`__hash__()`方法的对象，请注意`hash()`会根据宿主机的字长来截断返回值 |
+
+#### 🔍 用于类型检查
+
+| 函数                               | 说明                                                         |
+| ---------------------------------- | ------------------------------------------------------------ |
+| **`isinstance(obj, classinfo)`**   | 当前检查对象不是给定类型的，则函数总是返回`False`。当 *obj* 是 *classinfo* 的实例，则返回`True` |
+| **`issubclass(class, classinfo)`** | 如果 *class* 是 *classinfo* 的子类（直接、间接或抽象基类的子类），则返回`True` |
+
+关于上述两种方法的 *classinfo* 参数可以为一个类、多个类的元组。从`Python 3.10`开始，可以是一个`union`类型。
+
+#### 💡 用于帮助
+
+调用`help()`启动内置的帮助系统，此函数主要在<u>交互式</u>中使用。
+
+1. 如果没有实参，解释器控制台里会启动交互式帮助系统。
+2. 如果实参是一个字符串，则在模块、函数、类、方法、关键字或文档主题中搜索该字符串，并在控制台上打印帮助信息。
+3. 如果实参是其他任意对象，则会生成该对象的帮助页。

--- a/source/_posts/data-structure.md
+++ b/source/_posts/data-structure.md
@@ -1,0 +1,1236 @@
+---
+title: Python笔记：数据结构
+date: 2024-10-20 19:31:14
+tags:
+  - python
+  - tutorial
+categories:
+  - 笔记
+---
+
+> 这里我只是简单介绍一下Python数据结构的一些常用内容，详细内容请参考：[Python 3.13.0 文档](https://docs.python.org/zh-cn/3/) 。
+
+## 数据类型
+
+Python为我们提供了`type()`、`isinstance()`等方法来帮助我们查看变量的数据类型。执行如下代码我们得到了Python中的基本数据类型。这些基本类型都是由Python的标准库模块`builtins`提供。
+
+Python中的基本数据类型可以大致分为：**可变数据类型** | `Mutable Type`、**不可变数据类型** | `Immutable Type` 。可变数据在定义后可以进行修改；而不可变数据在定义后不可以进行修改，当我们对值为<span style='color:cyan'>不可变数据类型</span>的变量进行修改时，<u>实际上是删除原有数据后重新赋值而已</u>。
+
+* **不可变数据类型**：`int`、`float`、`bool`、`complex`、`str`、<span style='color:cyan'>**`tuple`**</span>、<span style='color:cyan'>**`bytes`**</span> 。
+* **可变数据类型**：`list`、`dict`、`set`、`bytearray` 。
+
+```python
+t1=1
+t2=3.14
+t3=3+4j
+t4=True
+t5='123'
+t6=[1, 2]
+t7=(1, 2)
+t8={1, 2}
+t9={'a':1}
+t10=b'00000001'
+t11=bytearray(t10)
+
+print(type(t1))     # <class 'int'>
+print(type(t2))     # <class 'float'>
+print(type(t3))     # <class 'complex'>
+print(type(t4))     # <class 'bool'>
+print(type(t5))     # <class 'str'>
+print(type(t6))     # <class 'list'>
+print(type(t7))     # <class 'tuple'>
+print(type(t8))     # <class 'set'>
+print(type(t9))     # <class 'dict'>
+print(type(t10))    # <class 'bytes'>
+print(type(t11))    # <class 'bytearray'>
+```
+
+我们详细介绍一下上面提到的数据类型：
+
+### 1. 数值类型
+
+Python的数值类型有：`int`、`bool`、`float`、`complex`：
+
+* **`int` & `bool`**：
+
+    **`Python 3`的整型是没有限制大小的**，可以当作`Long`类型使用，所以`Python 3`没有`Python 2`的`Long`类型。`Python 3`的布尔类型是整型的子类，需要注意的是布尔值首字母需要大写`True`。由于的布尔类型是整型的子类，在使用`==`比较时有以下登上成立：
+
+    ```python
+    print(1==True)	# True
+    print(0==False)	# True
+    ```
+
+* **`float`**：
+
+    浮点型由整数部分与小数部分组成，浮点型也可以使用科学计数法表示，**`2.5e5`即`2.5*10^5`**。
+
+    ```python
+    f1=250000.0
+    f2=2.5e5
+    print(f1==f2)	# True
+    ```
+
+* **`complex`**：
+
+    即复数类型，由实部与虚部组成，可以使用以下两种方式生成。
+
+    ```python
+    c1=3+4j
+    c2=complex(3, 4)
+    
+    print(c1==c2)	# True
+    ```
+
+
+### 2. 序列类型
+
+Python 的序列类型有：`list`、`tuple`、`set`、`dict`。这四者的异同主要体现在三方面：元素的<span style='color:cyan'>可变性</span>、<span style='color:cyan'>唯一性</span>、<span style='color:cyan'>有序性</span>。
+
+|          | 可变性 | 唯一性            | 有序性            |
+| -------- | ------ | ----------------- | ----------------- |
+| **列表** | ✅      | ❌                 | ✅                 |
+| **元组** | ❌      | ❌                 | ✅                 |
+| **集合** | ✅      | ✅                 | ❌                 |
+| **字典** | ✅      | ✔️ \| `Unique Key` | ✔️ \| `python 3.7` |
+
+* **可变性**：元素在定义后是否可以进行修改。
+
+* **唯一性**：元素在同一序列中是否可以重复。
+
+    这些可以有元素唯一性特性的数据类型在判断内部元素是否具有唯一性时，是调用元素的 `__eq__()`、`__hash__()` 方法来判断的，这里需要注意的是：对于`dict`而言，是`dict`的唯一性是对于**键**而言的。
+
+    我们将这类可以判断唯一性的数据类型称为 **<span style='color:cyan'>Hashable</span>** 类型。以下是常用类型的唯一性判断标准：
+
+    1. `Immutable Type` 大多数都是 <span style='color:cyan'>可哈希</span> 的；
+
+    2. `Mutable Container` 都 <span style='color:cyan'>不可哈希</span> 的，例如 `list`、`dict` ；
+
+    3. `Immutable Container` 仅当它们的元素均为可哈希时才是 <span style='color:cyan'>可哈希</span> 的，例如 `tuple`、`frozenset` 。
+
+    **用户定义类的实例对象默认是可哈希的**，它们在比较时一定不相同（除非是与自己比较），它们的哈希值是使用`id()`获取的。`id(object)` 返回对象的 <span style='color:cyan'>标识值</span> 。该值是一个整数，在此对象的生命周期中保证是唯一且恒定的。两个生命期不重叠的对象可能具有相同的`id()`值。
+
+    如果我们想为自己的类实例定制化`hash(ins)`的输出结果，可以重写 `__hash__()`、`__eq__()` 这两个魔术方法，以下是示例：
+
+    ```python
+    class HashableClass:
+        def __init__(self, id):
+            self._id = id
+    
+        def __hash__(self):
+            # Get hash, make sure using same id with __eq__()
+            return hash(self._id)
+    
+        def __eq__(self, other):
+            # Check self equals to other
+            if isinstance(other, HashableClass):
+                return self._id == other._id
+            return False
+    ```
+
+* **有序性**：元素的存储顺序是否有序。
+
+    列表与元组的有序性显而易见，这里我们着重讨论一下字典的有序性。
+
+    字典在`Python 3.7`之前是随机存储键值对的，我们使用`dict.popitem()`弹出的是一个随机的键值对。在`Python 3.7`之后，字典采用 **后进先出**\| ``LIFO``的策略管理键值对，故我们使用`dict.popitem()`弹出的始终是最近进入字典的键值对。
+
+    ```python
+    d1={1: 'None',2: 'None',3: 'None', 4: "None"}
+    d1.popitem()    
+    print(d1)       # {1: 'None', 2: 'None', 3: 'None'}
+    d1[4]=123
+    d1[2]=123
+    d1.popitem()
+    print(d1)       # {1: 'None', 2: 123, 3: 'None'}
+    ```
+
+    需要注意的是，只有<span style='color:cyan'>新增的键</span>才被视为<span style='color:cyan'>进</span>，如果使用`dict.update()`、`dict[key]=value`来更新字典内容不会使该键值对重新进入字典。
+
+    ```python
+    d1={1: 'None',2: 'None',3: 'None', 4: "None"}
+    d1.popitem()
+    print(d1)       # {1: 'None', 2: 'None', 3: 'None'}
+    d1[4]=123
+    d1.update({1:1})
+    d1.popitem()
+    print(d1)       # {1: 'None', 2: 123, 3: 'None'}
+    ```
+
+#### 🔧 公共方法
+
+以下是这四种类型的公共方法：
+
+* **`len()`、`max()`、`min()`** ：
+
+    `builtins`提供了列表、元组和集合的通用函数：`len()`、`max()`、`min()`。
+
+    ```python
+    targets = {
+     'list': [1, 2, 2],
+     'tuple': (1, 2, 2),
+     'set': {1, 2},
+    }
+    functions = [len, max, min]
+    
+    for key in targets:
+     print(key)
+     for f in functions:
+         print(f"\t{f.__name__}({key}) => {f(targets[key])}")
+     print()
+    ```
+
+    <span style='color:cyan'>字典也可以使用上述通用函数</span>。对于`len()`所有字典都可以使用，对于`max()`、`min()`则只有当作为键的类型实现了关于比较的方法后才能使用`max()`、`min()`。需要实现的魔术方法有：`__eq__()`、`__lt__()`、`__le__()`、`__gt__()`、`__ge__()`等。
+
+    ```python
+    dict1={True: 1, 2: 2, 3.14:3}
+    dict2={True: 1, 2: 2, "3.14":3}
+    dicts={
+     'dict1': dict1,
+     'dict2': dict2,
+    }
+    functions = [len, max, min]
+    
+    for dict_name in dicts:
+     for f in functions:
+         try:
+             print(f"{f.__name__}({dict_name}) = {f(dicts[dict_name])}")
+         except TypeError as err:
+             print(f"{f.__name__}({dict_name}) => {err}")
+    
+    # # Result: 
+    # # len(dict1) = 3
+    # # max(dict1) = 3.14
+    # # min(dict1) = True
+    # # len(dict2) = 3
+    # # max(dict2) => '>' not supported between instances of 'str' and 'int'
+    # # min(dict2) => '<' not supported between instances of 'str' and 'bool'
+    ```
+
+* **切片与删除**：
+
+    列表、元组等**有序序列**都支持切片，需要注意的是虽然 ***字典*** 也可以看作有序序列 ，但其却并不支持切片操作。
+
+    切片遵循<span style='color:cyan'>**左闭右开**</span>的裁切方式。左`index`大于右`index`，左右`index`大于`len(list)`都不会报错，请在裁切时做好<u>防御性编程</u>。以下是切片实验代码，运行他们以便你更好的了解切片：
+
+    ```python
+    l1=[1,2,3,4,5]
+    l2=l1[:]
+    l3=l1[0:]
+    l4=l1[0:-1] 
+    l5=l1[4:3]  # Wont report error
+    l6=l1[7:8]  # Wont report error
+    
+    print(l1)   # [1, 2, 3, 4, 5]
+    print(l2)   # [1, 2, 3, 4, 5]
+    print(l3)   # [1, 2, 3, 4, 5]
+    print(l4)   # [1, 2, 3, 4]
+    print(l5)   # []
+    print(l6)   # []
+    ```
+
+    列表、元组、字典等**有序序列**都支持使用`del`关键字进行删除操作，***集合*** 仅支持使用`del`删除集合本身：
+
+    ```python
+    l1=[1,2,3]		# list
+    d1={1: 1, '1': 1}	# dict
+    t1=(1,2,3)		# tuple
+    
+    del l1[1]
+    del d1['1']
+    
+    print(l1)       	# [1, 3]
+    print(d1)       	# {1: 1}
+    
+    del l1
+    del d1
+    del t1
+    
+    s1={1,2,3}
+    del s1
+    ```
+
+#### 🧰 实例方法
+
+上述四种类型的使用以及实例方法如下：
+
+* **`list`常用实例方法**：
+
+    | 方法                                                         | 说明                                                         |
+    | ------------------------------------------------------------ | ------------------------------------------------------------ |
+    | `list.count(obj)`                                            | 统计某个元素在列表中出现的次数                               |
+    | `list.clear()`                                               | 清空列表                                                     |
+    | `list.append(obj)`                                           | 在列表末尾添加新的对象                                       |
+    | `list.remove(obj)`                                           | 移除列表中某个值的第一个匹配项                               |
+    | `list.insert(index, obj)`                                    | 从列表中找出某个值第一个匹配项的索引位置                     |
+    | `list.extend(seq)`                                           | 在列表末尾一次性追加另一个序列中的多个值                     |
+    | <span style='color: cyan;white-space: nowrap'>`list.sort(key=None, reverse=False)`</span> | 对原列表进行排序                                             |
+    | `list.reverse()`                                             | 反转列表中元素                                               |
+    | **`list.copy()=>list`**                                      | 复制列表                                                     |
+    | **`list.pop(index=-1)=>obj`**                                | 移除列表中的一个元素（默认最后一个元素），并且返回该元素的值 |
+
+* **`set`常用实例方法** ：
+
+    | 方法                                                         | 说明                                                         |
+    | ------------------------------------------------------------ | ------------------------------------------------------------ |
+    | `set.add(hashable_el)`                                       | 向集合添加一个 ***Hashable*** 元素                           |
+    | `set.clear()`                                                | 移除集合中的所有元素                                         |
+    | `set.copy() => set`                                          | 返回集合的浅拷贝                                             |
+    | <span style='color:silver'>\# *删除操作* ：</span>           |                                                              |
+    | `set.pop()`                                                  | 从集合中移除并返回任意一个元素。 如果集合为空则会引发`KeyError` |
+    | `set.remove(hashable_el)`                                    | 从集合中移除元素 *hashable_el*。 如果 *hashable_el* 不存在于集合中则会引发`KeyError` |
+    | `set.discard(hashable_el)`                                   | 如果元素 *hashable_el* 存在于集合中则将其移除                |
+    | <span style='color:silver'>\# *原集合不变返回新集合* ：</span> |                                                              |
+    | `set.isdisjoint(other)=>bool`                                | 判断 *set* 是否与 *other* **无交集**                         |
+    | `set.issubset(other)=>bool`                                  | 判断 *set* 是否为 *other* 的子集                             |
+    | `set.issupperset(other)=>bool`                               | 判断 *set* 是否为 *other* 的超集                             |
+    | <span style='color:silver'>\# *原集合不变返回新集合* ：</span> |                                                              |
+    | `set.union(other)=>set`                                      | 返回两个集合的合集                                           |
+    | `set.difference(other)=>set`                                 | 返回两个集合的差集                                           |
+    | `set.intersection(other)=>set`                               | 返回两个集合的交集                                           |
+    | `set.symmetric_difference(other)=>set`                       | 返回两个集合中不重复的元素集合                               |
+    | <span style='color:silver'>\# *在原集合上更新* ：</span>     |                                                              |
+    | `set.update(other)`                                          | 为集合添加来自 *others* 中的所有元素                         |
+    | `set.difference_update(other)`                               |                                                              |
+    | `set.intersection_update(other)`                             |                                                              |
+    | `set.symmetric_difference_update(other)`                     |                                                              |
+
+    注意！`set`元素必须为 ***Hashable*** 元素，如果不是则会报错`KeyError`。
+
+* **`dict`**：
+
+    我们可以使用多种类型实例作为字典的键，但需要注意的是，该类型实例必须为 ***Hashable*** 元素。即实现了`__hash__()`、`__eq__()`方法。
+
+    当我们使用`str`类型作为字典的键时，不可以省略`‘’`，这一点不同于`JavaScript`。
+
+    ```python
+    dict1={
+    	'a': 100,
+    	'b': True
+    }
+    # Realize iterable
+    for i in dict1:             	# a 100
+    	print(i, dict1[i])      # b True
+    ```
+
+    我们可以通过字典键来管理字典内容：
+
+    ```python
+    dict1={}
+    dict1['key1']=1
+    dict1[2]=2
+    print(dict1)    # {'key1': 1, 2: 2}
+    
+    del dict1[2]
+    print(dict1)    # {'key1': 1}
+    ```
+
+    字典的常用实例方法如下：
+
+    | 方法                                                         | 说明                                                         |
+    | ------------------------------------------------------------ | ------------------------------------------------------------ |
+    | <span style='white-space: nowrap'>`fromkeys(iterable, value=None)=>dict`</span> | 使用来自 *iterable* 的键创建一个新字典，并将键值设为 *value*。`fromkeys()`是`dict`类型的静态方法，使用过程如下： |
+    
+    ```python
+    iter=[1,2,3]
+    dict1=dict.fromkeys(iter, 'hello')
+    print(dict1)	# {1: 'hello', 2: 'hello', 3: 'hello'}
+    ```
+    
+    | 方法                                                       | 说明                                                         |
+    | ---------------------------------------------------------- | ------------------------------------------------------------ |
+    | `dict.clear()`                                             | 移除字典中的所有元素                                         |
+    | `dict.copy()`                                              | 返回原字典的浅拷贝                                           |
+    | <span style='color:silver'>\# *字典值获取方法* ：</span>   |                                                              |
+    | `dict.get(key, default=None)`                              | 如果 *key* 存在于字典中则返回 *key* 的值，否则返回 *default* 。注意  *default* 初始值为`None`因此不会为报`KeyError` |
+    | `dict.pop(key[,default])=>value`                           | 如果 *key* 存在于字典中则将其移除并返回其值，否则返回 *default*。 如果 *default* 未给出且 *key* 不存在于字典中，则会引发`KeyError` |
+    | <span style='color:silver'>\# *字典键值获取方法* ：</span> |                                                              |
+    | `dict.popitem()=>(key, value)`                             | 从字典中移除并返回一个`(key, value)`对，键值对会按 LIFO 的顺序被返回；<br/><span style='color:pink'>`Python 3.7` 采用 LIFO 策略即`stack`，管理字典的键值对。在 `Python 3.7` 之前此方法会移除并返回一个随机键值对。</span> |
+    | <span style='color:silver'>\# *字典键值更新方法* ：</span> |                                                              |
+    | `dict.update(other)`                                       | 使用 *other* 中的键值对更新 *dict* ，也可以使用`dict.update(key1=value1, ...)`的方式更新。注意使用`dict.update(key1=value1)`时，字典会自动将 *key1* 转化为`‘key1’`字符串作为键 |
+    
+     ```python
+     d1={1: 'None'}
+     d1.update(key='None')
+     print(d1)				# {1: 'None', 'key': 'None'}
+     ```
+    
+    | 方法                                                         | 说明                                                         |
+    | ------------------------------------------------------------ | ------------------------------------------------------------ |
+    | <span style='white-space: nowrap'>`dict.setdefault(key, default=None)`</span> | 如果字典存在键 *key* ，返回它的值。如果不存在，插入值为 *default* 的键 *key* ，并返回 *default* |
+    | <span style='color:silver'>\# *字典输出方法* ：</span>       |                                                              |
+    | `dict.items()`                                               | 返回由字典项`(key, value)`组成的一个新视图，可以视作一个 *<span style='color:cyan'>iterable_tuples</span>* |
+    | `dict.keys()`                                                | 返回由**字典键**组成的一个新视图                             |
+    | `dict.values()`                                              | 返回由**字典值**组成的一个新视图                             |
+
+* **`tuple`** ：
+
+    元组中只包含一个元素时，需要在元素后面添加逗号`,`，否则括号会被当作运算符使用：
+    
+    ```python
+    t1=(50)
+    t2=(50, )
+    
+    print(type(t1))     # <class 'int'>
+    print(type(t2))     # <class 'tuple'>
+    ```
+    
+    元组之间可以使用运算符进行运算。这就意味着他们可以组合和复制，运算后会生成一个新的元组。
+    
+    ```python
+    t1=(50, 10, 5)
+    t2=(50, 20, 30)
+    t3=t1+t2
+    t4=t1*2
+    
+    print(t3)       # (50, 10, 5, 50, 20, 30)
+    print(t4)       # (50, 10, 5, 50, 10, 5)
+    ```
+
+### 3. 字符串
+
+在Python中我们可以使用`'`、`"` 、`"""`创建字符串，其中单引号与双引号用于创建普通字符串，三引号可以用于创建多行字符串与多行注释。以下是字符串的简单使用样例：
+
+```python
+str1='123'
+str2="123"
+str3 = """This is a
+               multi-line string."""
+
+print(str1)
+print(str2)
+print(str3)
+
+# # Result:
+# # 123
+# # 123
+# # This is a
+# #            multi-line string.
+
+def funcDocString(attr1, attr2):
+    """Details in <Python|Best Exercise>"""
+    return f'{attr1} {attr2}'
+```
+
+下面我们从以下方面来学习字符串：
+
+#### ✏️ 常用转义字符
+
+常用模板字符串有：**换行符** | `\n`、 **回车符** | `\r`、 **制表符** | `\t`、 **单引号** | `\'`、 **双引号** | `\"`、 **续行符** | `\`、 **反斜杠** | `\\` 。
+
+```python
+print("a\nb")		# a
+			# b
+print("a\rb")		# b
+print("a\tb")		# a    b
+print("a\'b")		# a'b
+print("a\"b")		# a"b
+print("a\			
+b")			# ab
+print("a\\b")		# a\b
+```
+
+#### ➕ 字符串运算符
+
+常用的字符串运算符有：
+
+| 运算符                                                  | 说明                                                         |
+| ------------------------------------------------------- | ------------------------------------------------------------ |
+| `+`                                                     | 用于字符串拼接，当使用字符串拼接类型实例时，会调用实例对象的`__str__`方法生成对应字符串 |
+| `*`                                                     | 用于字符串重复输出                                           |
+| <span style='white-space: nowrap'>`in`、`not in`</span> | 用于判断字符串中是否包含指定字符串                           |
+| `r''`                                                   | 原始字符串，不能输出转义字符                                 |
+| `f''`                                                   | 模板字符串，等同于`‘’.format(*args)`                         |
+| `''%()`                                                 | 格式化字符串，用于格式化输出                                 |
+
+`+`用于字符串拼接，当使用字符串拼接类型实例时，会调用实例对象的`__str__`方法生成对应字符串；`*`用于字符串重复输出。
+
+```python
+s="123"
+print(s+"456")	# 123456
+print(s*2)		# 123123
+```
+
+`in`与`not in`这两个成员运算符作用于字符串时不同于列表、元组与字典。当这两个成员运算符作用于字符串时更像是执行了`bmp`算法，而当它们作用于列表等容器时<span style='color:cyan'>是将比较对象看作子元素而不是子集</span>。
+
+```python
+s1="123"
+s2="123456"
+
+l1=[1,2,3]
+l2=[1,2,3,4,5,6]
+
+print('1' in s2)    # True
+print(s1 in s2)     # True
+
+print(1 in l2)      # True
+print(l1 in l2)     # False
+```
+
+
+当我们不想在字符串中使用转义字符时，可以使用原始字符串`r''`。
+
+```python
+print(r'\n\r\t\'\"\\')  # \n\r\t\'\"\\
+```
+
+#### 🧩 模板字符串
+
+当我们需要拼接多个字符串与对象时，可以使用模板字符串进行拼接。Python的模板字符串有以下两种使用方式：
+
+* `“{0}, {1}”.format(*args)`：我们使用`{index}`来为`format(*args)`中对应的对象占位，当输出字符串时会自动调用对象的`__str__()`方法，将生成的字符串插入到对应的`{index}`中；
+* `f“{a1}, {a2}”`：我们也可以使用类似`JavaScript`中生成模板字符串的方式，给我们的模板字符串插入对应对象调用`__str__()`方法返回的字符串；
+
+#### 🧵 字符串格式化
+
+Python支持格式化字符串的输出。需要注意的是Python的字符串格式化不止服务于`print`方法，这是属于字符串的格式化方法。以下是Python字符串格式化符号：
+
+| 符号 | 描述                                 |
+| :--- | :----------------------------------- |
+| `%c` | 格式化字符及其`ASCII`码              |
+| `%s` | 格式化字符串                         |
+| `%d` | 格式化整数                           |
+| `%u` | 格式化无符号整型                     |
+| `%o` | 格式化无符号八进制数                 |
+| `%x` | 格式化无符号十六进制数               |
+| `%X` | 格式化无符号十六进制数（大写）       |
+| `%f` | 格式化浮点数字，可指定小数点后的精度 |
+| `%e` | 用科学计数法格式化浮点数             |
+| `%E` | 作用同`%e`，用科学计数法格式化浮点数 |
+| `%g` | `%f`和`%e`的简写                     |
+| `%G` | `%f`和`%E`的简写                     |
+| `%p` | 用十六进制数格式化变量的地址         |
+
+以下是字符串格式化的辅助符号：
+
+| 符号      | 说明                                                  |
+| --------- | ----------------------------------------------------- |
+| `*`       | 用于动态指定宽度或精度（如%*.*f`）                    |
+| `-`       | 左对齐输出内容                                        |
+| `+`       | 在正数前显示加号（如`+3.2f`）                         |
+| `<sp>`    | 正数前显示空格（负数仍显示负号）                      |
+| `#`       | 启用进制前缀（如`0`、`0x`、`0X`）用于八进制或十六进制 |
+| `0`       | 使用零填充输出的空白部分（如`08d`表示宽度为8，前补0） |
+| `%%`      | 输出一个`%`字符                                       |
+| `(*args)` | 使用元组或列表映射多个格式变量                        |
+| `m.n`     | `m`表示最小总宽度，`n`表示小数点后的位数（如`%6.2f`） |
+
+```python
+s="%d\n%6.1f\n%  d\n%%"%(1, 6.111111, 1)
+print(s)
+
+# # Result:
+# # 1
+# #    6.1
+# #  1
+# # %
+```
+
+### 4. 字节数组类型
+
+Python的字节数组类型有：`bytes`、`bytearray`。其中，`bytes`是二进制形式的不可变序列，`bytearray`是二进制形式的可变序列。由于`Python 3`的自带字符默认使用`utf-8`格式编码和显示，故这两种字节数组类型的默认编码格式是`utf-8`。
+
+关于`bytes`与`bytearray`需要注意的地方有：
+
+#### 🧱 字节数组与hashable
+
+`bytes`的实现了`__hash__()`、`__eq__()`这两个魔术方法，故其实例对象可以作为字典键与集合元素，而`bytearray`则不行。
+
+```python
+s={1, 2}
+
+b=b"123"
+ba=bytearray(b)
+print(b.__hash__())		# Run succeed
+s.add(b)				
+print(s)			# {b'123', 1, 2}
+
+s.add(ba)			# TypeError: unhashable type: 'bytearray'
+```
+
+#### 🔣 字节数组与`int`
+
+`bytes`与`bytearray`的底层是`int`类型，*<u>取值</u>* 与 *<u>切片</u>* 的结果如下：
+
+```python
+b=b"123"
+ba=bytearray(b)
+
+slice_b=b[:]
+slice_ba=ba[:]
+
+print(b[0], type(b[0]))         # 49 <class 'int'>
+print(ba[0], type(ba[0]))       # 49 <class 'int'>
+
+print(slice_b, type(slice_b))   # b'123' <class 'bytes'>
+print(slice_ba, type(slice_ba)) # bytearray(b'123') <class 'bytearray'>
+```
+
+#### 🛠️ 创建字节数组
+
+我们执行`help(bytearray)`可以看到`bytearray`的构造函数用法如下。
+
+```python
+bytearray(iterable_of_ints) 		# -> bytearray
+bytearray(string, encoding[, errors]) 	# -> bytearray
+bytearray(bytes_or_buffer) 		# -> mutable copy of bytes_or_buffer
+bytearray(int) 		# -> bytes array of size given by 
+			# the parameter initialized with null bytes
+bytearray() 		# -> empty bytes array
+```
+
+我们执行`help(bytes)`则可以看到`bytes`的构造函数可以用如下方法使用：
+
+```python
+bytes(iterable_of_ints) 				# -> bytes
+bytes(string, encoding[, errors]) 			# -> bytes
+bytes(bytes_or_buffer) 					# -> immutable copy of 
+							# 	bytes_or_buffer
+bytes(int) 			# -> bytes object of size given by the 
+				# parameter initialized with null bytes
+bytes() 			# -> empty bytes object
+```
+
+我们发现这里`help`告诉我们的整型序列不是用的`list`、`tuple`这些关键词，而是用 *<span style='color:cyan'>iterable</span>* 描述的整型序列。如果想要我们的类支持通过`bytes`或者`bytearray`实现二进制序列化，则需要实现`__iter__()`这一魔术方法。关于此方法的说明和使用请参考下一节[面向对象编程](#面向对象编程)。
+
+```python
+class MyCollection:
+def __init__(self, data):
+self.data = data
+
+def __iter__(self):
+return iter(self.data)
+```
+
+字节数组构造函数的调用规律如下：
+
+1. 可以使用可遍历的`int`序列创建，例如：`(1,2,3)`、`{1,2,3}`等。
+
+    ```python
+    b1=bytes((1,2,3))
+    b2=bytes([1,2,3])
+    b3=bytes({1,2,3})
+    b4=bytes({1: '123'})	# Int-keys of dict is iterable
+    
+    print(b1)               # b'\x01\x02\x03'
+    print(b2)               # b'\x01\x02\x03'
+    print(b3)               # b'\x01\x02\x03'
+    print(b4)               # b'\x01'
+    ```
+
+2. 可以使用`string`值创建，在创建时需要指定编码方式，默认是`utf-8`。
+
+3. 可以使用`bytes`或者`buffer`创建。
+
+4. 可以使用`int`值创建，根据`int`值生成对应长度的字节数组。
+
+    ```python
+    b1=bytes(1)
+    
+    for i in b1:
+        print(i)		# 0 
+    ```
+
+5. 可以创建空的`bytes`或者`bytearray`。 
+
+Python为我们提供了类型转换工具，这有助于我们更好的处理数据。我们常用`type_name(other_type_ins)`的方式进行类型转换，这实际上就是调用了对于类型的构造函数进行转换。Python的基本数据类型的类型转换规则如下：
+
+1. **数值类型间可以相互转换**：
+
+    ```python
+    raw_list=[1, 1.0, 3+4j, True]
+    trans_functions=[int, float, complex, bool]
+    
+    for raw in raw_list:
+    for trans in trans_functions:
+    try:
+       print(f"{trans.__name__}({raw}) => {trans(raw)}")
+    except TypeError as err:
+       print(f"{trans.__name__}({raw}) | {err}")
+    
+    # # Result:
+    # # int(1) => 1
+    # # float(1) => 1.0
+    # # complex(1) => (1+0j)
+    # # bool(1) => True
+    # # int(1.0) => 1
+    # # float(1.0) => 1.0
+    # # complex(1.0) => (1+0j)
+    # # bool(1.0) => True
+    # # int((3+4j)) | can't convert complex to int
+    # # float((3+4j)) | can't convert complex to float
+    # # complex((3+4j)) => (3+4j)
+    # # bool((3+4j)) => True
+    # # int(True) => 1
+    # # float(True) => 1.0
+    # # complex(True) => (1+0j)
+    # # bool(True) => True
+    ```
+
+    执行上述代码，我们可以发现只有`complex`的转换成其他类型时有些限制，其他类型之间都可以相互转换。
+
+2. **`list`、`set`、`tuple`与字节数组类型间可以相互转换**：
+
+    稍微更改上一节的代码并执行可以发现，`list`、`set`、`tuple`之间可以相互转换。当这三者的元素数据类型只有`int`或者`bool`时，可以通过调用`bytes()`、`bytearray()`转换为字节数组。
+
+    ```python
+    list1=[1,2,True]
+    tuple1=(1,2,3.1)
+    set1={1,2,'3'}
+    
+    raw_list=[list1, tuple1, set1]
+    trans_functions=[list, tuple, set, bytes, bytearray]
+    
+    for raw in raw_list:
+    for trans in trans_functions:
+    try:
+       print(f"{trans.__name__}({raw}) => {trans(raw)}")
+    except TypeError as err:
+       print(f"{trans.__name__}({raw}) | {err}") 
+    ```
+
+3. `dict`与`list`、`set`、`tuple`、`bytes`、`bytearray`的**转换规则**：
+
+    字典在使用`list()`、`set()`、`tuple()`转换为相应类型时，是将字典值数组作为可遍历序列进行转换的。使用`bytes()`、`bytearray()`进行转换时，值类型也要满足上小节提到的要求。
+
+    其他可遍历类型若想转化为`dict`，可以自己通过遍历实现或者采用使用`dict`的静态方法 `fromkeys(iterable, value=None)` 实现。  
+
+4. `bool()`还支持转换其他数据类型为`bool`。
+
+5. `str`类型可以被看作字符数组与`list`、`tuple`、`set`进行类型转换。
+
+6. 如果需要我们的类支持向这些基本数据类型进行转换，需要支持编写相应的魔术方法。目前支持的魔术方法有：`__bool__()`、`__int__()`、`__float__()`、`__complex__()`等。魔术方法详见下一节[面向对象编程](#面向对象编程)。
+
+## 面向对象编程
+
+Python是一门面向对象的语言，所有基本数据类型对应的类都可以在`builtins`中找到。在本节中我们将从以下方面了解Python的面向对象编程：
+
+### 1.`class`基础
+
+我们使用`class`关键字定义一个类，以下是定义类时需注意的事项：
+
+#### 🧬 属性与方法
+
+* 关于类的属性与方法有如下实现细节：
+
+    * 私有字段：我们可以使用`__`作为属性名或者方法名的前缀，这样定义的方法就不能通过类的实例对象访问。
+
+    * **静态属性**：当我们用`ClassName.static_attr`调用属性时，得到的就是该类型的静态属性。静态属性不能通过实例对象进行修改，只能直接修改。
+
+    * **静态方法**：我们可以使用 `@staticmethod` 装饰器来装饰类的 <u>实例方法</u> ，装饰后的方法应当没有入参`self`，我们可以用`ClassName.static_func()`来调用静态方法。
+
+    * <span style='color:cyan'>**抽象类方法**</span>：我们可以使用 `@abstractmethod` 装饰器来装饰类的 <u>抽象方法</u> ，在定义类的抽象方法时，我们只需要给出方法的入参即可，方法的函数体与返回值使用`pass`代替。当有子类继承了该类，需要实现该抽象方法。
+
+        ```python
+        class Test:
+            @abstractmethod
+            def __abstract_func(self):
+                pass
+        
+        class SubTest:
+            def __abstract_func(self):
+                print("Writing implement here")
+        ```
+
+    * <span style='color:cyan'>**类方法**</span>：我们可以使用 `@classmethod` 装饰器来装饰类的 <u>类方法</u>。
+
+        与实例方法不同，类的类方法用于处理类本身即`cls`对象，我们可以通过`cls`对象访问类中的静态方法或者属性，需要注意的是类的静态属性与静态方法实际上就是类的元类实例即`cls`对象的实例方法与属性。
+
+        ```python
+        class Test:
+            @classmethod
+            def class_func(cls, *args, **kwargs):
+                pass
+        ```
+
+    * <span style='color:cyan'>**属性代理方法**</span>：我们可以使用 `@property`、`@xxx.getter`、`@xxx.setter`、`@xxx.deleter` 来代理类实例的属性或者私有属性。
+
+        需要注意的是 `@property`、`@xxx.getter` 实现的效果都是代理属性的获取功能，但是为了代码的可读性考虑，当我们需要对代理属性进行 **删、改、查** 操作时优先考虑后三者，当我们只需要 **查** 代理属性时优先考虑 `@property` 。
+
+        对于 `@property` 而言，`def property():` 是它实际的函数形式。我们除了在类定义时使用装饰器语法，还可以在元类中为类的方法添加 `@property` 。
+
+        ```python
+        class ImmutableMeta(type):
+            def __new__(cls, name, bases, dct):
+                for key, value in dct.items():
+                    print(key, value)
+                    if not key.startswith('__'):
+                        dct[key] = property(value)
+        
+                return super().__new__(cls, name, bases, dct)
+        
+        class MyClass(metaclass=ImmutableMeta):
+            def __init__(self, value):
+                self._value = value
+        
+            def get_value(self):
+                return self._value
+        
+        obj = MyClass(10)
+        print(obj.get_value) 
+        ```
+
+#### <span style='color:cyan'>👨‍👩‍👦 类的继承</span>
+
+Python实现了 **多继承** ，我们在编写类时支持通过`class ClassName(FatherClass1, FatherClass2)`的方式继承父类的属性与方法。Python的继承的**注意事项**有：
+
+* 子类实例对象访问父类的属性或者方法时，Python将 **<span style='color:cyan'>*从左往右*</span>** 依次查找父类中是否有对应方法。
+* 子类可以对父类的方法进行重写，`super()`是Python提供的用于子类调用父类属性或方法的一个方法。
+* 我们使用`super()`在子类中访问父类属性或方法时，不能访问父类的私有属性或方法。可以被看做在使用父类的一个实例对象。
+
+### 2.`class`进阶
+
+Python的所有类型都是由`builtins`的`object`类型继承而来，这意味着我们可以在所有类型中使用`object`的方法（`object`中没有属性）。我们执行`help(object)`得到`object`的内置方法如下：
+
+```shell
+Help on class object in module builtins:
+
+class object
+ |  ...
+ |
+ |  Methods defined here:
+ |  
+ |  __delattr__(self, name, /)		Implement delattr(self, name).
+ |  __dir__(self, /)			Default dir() implementation.
+ |  __eq__(self, value, /)		Return self==value.
+ |  __format__(self, format_spec, /)	Default object formatter.
+ |  __ge__(self, value, /)		Return self>=value.
+ |  __getattribute__(self, name, /)	Return getattr(self, name).
+ |  __gt__(self, value, /)		Return self>value.
+ |  __hash__(self, /)			Return hash(self).
+ |  __init__(self, /, *args, **kwargs)	Initialize self.  See help(type(self)).
+ |  __le__(self, value, /)		Return self<=value.
+ |  __lt__(self, value, /)		Return self<value.
+ |  __ne__(self, value, /)		Return self!=value.
+ |  __reduce__(self, /)			Helper for pickle.
+ |  __reduce_ex__(self, protocol, /)	Helper for pickle.
+ |  __repr__(self, /)			Return repr(self).
+ |  __setattr__(self, name, value, /)	Implement setattr(self, name, value).
+ |  __sizeof__(self, /)			Size of object in memory, in bytes.
+ |  __str__(self, /)			Return str(self).
+ |
+ |  ----------------------------------------------------------------------
+ |  Class methods defined here:
+ |  
+ |  __init_subclass__(...) from builtins.type
+ |      This method is called when a class is subclassed.
+ |      
+ |      The default implementation does nothing. It may be
+ |      overridden to extend subclasses.
+ |  
+ |  __subclasshook__(...) from builtins.type
+ |      Abstract classes can override this to customize issubclass().
+ |      
+ |      This is invoked early on by abc.ABCMeta.__subclasscheck__().
+ |      It should return True, False or NotImplemented.  If it returns
+ |      NotImplemented, the normal algorithm is used.  Otherwise, it
+ |      overrides the normal algorithm (and the outcome is cached).
+ |  
+ |  ----------------------------------------------------------------------
+ |  Static methods defined here:
+ |  
+ |  __new__(*args, **kwargs) from builtins.type
+ |      Create and return a new object.  See help(type) for accurate signature.
+ |  
+ |  ----------------------------------------------------------------------
+ |  Data and other attributes defined here:
+ |  
+ |  __class__ = <class 'type'>
+ |      type(object) -> the object's type
+ |      type(name, bases, dict, **kwds) -> a new type
+```
+
+其中形如`__xxx__()`、`__xxx__`的属性或者方法我们称之为 <span style='color:cyan'>*魔术属性*</span> 或者 **<span style='color:cyan'>*魔术方法*</span>** 。在编程语言中，我们常用 **魔术数字** | `magic number` 指代那些在直接硬编码的数字，它们通常没有一个明确的名称或含义。Python中的魔术字段也是硬编码在Python基础库或者解释器里面，它们各自服务于Python类型实例生命周期的不同片段。需要说明的一点是，
+
+<u>Python会因不同的`PEP(Python Enhancement Proposal)`会不断添加删除魔术方法</u>，故下面分类列出的魔术方法具有**时效性**，请在使用时查看相应Python文档或者使用`help()`工具。魔术方法按功能可分为如下几类：
+
+#### 🛠️ 创建实例
+
+| 方法                                                         | 说明                                                         |
+| ------------------------------------------------------------ | ------------------------------------------------------------ |
+| `__init__(self, *args, **kwargs)`                            | 用于初始化对象，在使用`ClassName()`时自动调用。这里的`self`对象是由`__new__()`创建的 |
+| <span style='color:cyan'>`__new__(cls, *args, **kwargs)`</span> | 在`__init__()`之前调用，用于创建`self`对象。`cls` 代表类本身 |
+| <span style='color:silver'>`__del__(self)`</span>            | 在对象被垃圾回收时执行特定的操作，如关闭`socket`，文件描述符等。因为当Python解释器退出时，对象有可能依然未被释放，因此`__del__()`中定义册操作不一定能被执行，故在实际中应避免使用`__del__()` |
+
+#### 🎮 实例属性
+
+| 方法                                                         | 说明                                                         |
+| ------------------------------------------------------------ | ------------------------------------------------------------ |
+| <span style='color:cyan'>`__getattr__(self, item)`</span> | 拦截访问实例不存在的属性，即在访问不存在实例的`__dict__`中的`key`时，进行调用拦截 |
+| `__getattribute__(self, item)`                               | 拦截所有的实例属性访问操作，应当在函数体内避免使用`self.key`这会造成死循环 |
+| `__setattr__(self, key, value)`                              | 拦截所有的实例属性赋值操作，应当在函数体内避免使用`self.key=value`这会造成死循环 |
+| `__delattr__(self, item)`                                    | 拦截所有的实例属性清除操作，应当在函数体内避免使用`del self.key`这会造成死循环 |
+
+#### 🧭 描述实例
+
+* `__str__(self)`：Python 的`toString()`，使类型实例支持`print()`。
+
+* <span style='color:cyan'>`__repr__(self)`</span>：使类型实例支持`repr()`，`repr()` 方法用于获取对象的详细信息包括存储地址等。`__str__(self)` 中的信息一般是`__repr__()`的一部分
+
+* <span style='color:cyan'>`__format__(self, format_spec)`</span>：使类型实例支持 `“{}”.format(obj, key)` 或者 `f"{obj}"`、`f"{obj:key}"` 。
+
+    ```python
+    class EnableFormat:
+        value=None
+        default='default'
+        def __init__(self, value):
+            self.value = value
+    
+        def __format__(self, format_spec):
+            raw_out=''
+            if format_spec == 'value':
+                raw_out=self.value
+            elif format_spec == 'default':
+                raw_out=self.default
+            elif format_spec == '':
+                raw_out=f"EnableFormat(value={self.value}, \
+                	default={self.default})"
+            else:
+                raw_out=f"EnableFormat(value={self.value}, \
+                	default={self.default})"
+    
+            return raw_out
+    
+    test=EnableFormat('enter')
+    print(f"{test}")
+    print("{}".format(test))
+    print(f"{test:value}")
+    print("{:default}".format(test))
+    
+    # # Result:
+    # # EnableFormat(value=enter, default=default)
+    # # enter
+    # # EnableFormat(value=enter, default=default)
+    # # default
+    ```
+
+* `__hash__(self)`：用于 *Hashable* 类型定义，这前面已经介绍过了。
+
+* `__dir__(self)`：调用`dir()`方法时对象的返回值，一般不需要重写该方法，但在定义`__getattr__`时有可能需要重写，以打印动态添加的属性。
+
+* <span style='color:silver'>`__sizeof__(self)`</span>：定义`sys.getsizeof()`方法调用时的返回，指类的实例的大小，单位是字节，在使用 C 扩展编写`Python`类时比较有用。
+
+#### 🧪 实例间计算
+
+在这里主要介绍关于 ***比较计数*** 的魔术方法：
+
+| 方法                | 说明               |
+| ------------------- | ------------------ |
+| `__eq__(self, obj)` | 使类型实例支持`==` |
+| `__ne__(self, obj)` | 使类型实例支持`!=` |
+| `__le__(self, obj)` | 使类型实例支持`<=` |
+| `__ge__(self, obj)` | 使类型实例支持`>=` |
+| `__lt__(self, obj)` | 使类型实例支持`<`  |
+| `__gt__(self, obj)` | 使类型实例支持`>`  |
+
+此外还有许多计算相关的魔术方法，在这里就不一一列举了（因为用不到）。这里的`l`、`g`、`eq`分别是`less`、`greater`、`equal`的缩写，`le`、`lt`则是`less equal`、`less than`的缩写。
+
+#### 🧷 序列化实例
+
+定义一个不可变容器，只需要实现`__len__`和`__getitem__`，可变容器在此基础上还需实现`__setitem__`和`__delitem__`，如果希望容器是可迭代的，还需实现`__iter__`方法。
+
+| 方法                                                         | 说明                                                         |
+| ------------------------------------------------------------ | ------------------------------------------------------------ |
+| <span style='color:silver'># *不可变容器魔术方法* ：</span>  |                                                              |
+| `__len__(self)`                                              | 返回序列的长度，使类型实例支持`len(instance)`                |
+| <span style='color:silver'># *可变容器魔术方法* ：</span>    |                                                              |
+| `__getitem__(self, key)`                                     | 使类型实例支持`self[key]`                                    |
+| `__setitem__(self, key, value)`                              | 使类型实例支持`self[key]=value`                              |
+| `__delitem__(self, key)`                                     | 使类型实例支持`del self[key]`                                |
+| <span style='color:silver'># *可迭代容器魔术方法* ：</span>  |                                                              |
+| `__iter__(self)`                                             | 使类型实例支持`for item in self`。通常执行`__iter__()`返回的实例对象需要实现`__next__()`方法`__next__()`方法用于获取迭代器的下一个元素 |
+| `__reversed__(self)`                                         | 使类型实例支持`reversed(instance)`                           |
+| `__contains__(self, val)`                                    | 使类型实例支持`val in instance`                              |
+| <span style='color:silver'># *字典子类魔术方法* ：</span>    |                                                              |
+| <span style='color:cyan'>`__missing__(self)`</span>：。 | 当定制序列是 **<u>`dict`的子类</u>** 时，使用`dict[key]`读取元素而`key`没有定义时调用 |
+
+```python
+class MyDict(dict):
+    def __missing__(self, key):
+        return f"Key '{key}' not found."
+
+my_dict = MyDict(a=1)
+print(my_dict['a'])  # 1
+print(my_dict['b'])  # Key 'b' not found.
+```
+
+#### 🧼 可调用化实例
+
+`__call__(self, *args, **kwargs)`：使类型 <u>实例像函数一样调用</u> 。需要注意的是当我们在元类中书写该方法时有些许不同，关于元类的详见下一小节 <u>`type` 与元类</u> 。
+
+```python
+class FunctionGenerator:
+    def __call__(self, s):
+        return s**2;
+
+func=FunctionGenerator()
+print(func(2))
+```
+
+#### ♻️ 复制实例
+
+`copy`模块是Python的基础库之一。其中，`copy.copy()`是浅复制，常用于 <u>*不可变数据*</u> 的复制，当对 <u>*可变数据类型*</u> 进行浅复制时，只是复制了对象本身与对象包含的引用，不是复制了指向的对象。`copy.deepcopy()`是深复制，它会递归复制需要复制的对象。
+
+* `__copy__(self)`：执行`copy.copy()`时调用。
+
+* `__deepcopy__(self, memodict={})`：执行`copy.deepcopy()`时调用。`memodict`用于缓存目前已经复制的对象，以下是参考代码：
+
+    ```python
+    class Copy:
+        def __init__(self, value):
+        	self.value=value
+    
+        def __deepcopy(self, memodict={}):
+            # Copy part code, base on your class data structure
+            new=Copy(self.value)
+            memodict[id(new)]=new
+    
+            return new
+    ```
+
+#### 🪜 上下文管理
+
+Python 中使用`with`语句执行上下文管理，处理内存块被创建时和内存块执行结束时上下文应该执行的操作，上下文即程序执行操作的环境，包括异常处理，文件开闭。有两个魔术方法负责处理上下文管理。
+
+* <span style='color:cyan'>`__enter__(self)`</span>：上下文创建时执行的操作，该方法返回`as`后面的对象。
+
+* <span style='color:cyan'>`__exit__(self, exc_type, exc_val, exc_tb)`</span>：上下文结束时执行的操作。
+
+    ```python
+    class Closer:
+        def __init__(self, obj):
+            self.obj = obj
+    
+        def __enter__(self):
+            print('__enter__ called')
+            return self.obj # bound to target
+    
+        def __exit__(self, exception_type, exception_val, trace):
+            print('__exit__ called')
+            try:
+               self.obj.close()
+            except AttributeError:
+               print('Not closable. here')
+               return True
+    
+    with Closer(open("1.txt", "w")) as f:
+        f.write("1") 
+    ```
+
+
+#### 🧱 描述器
+
+描述器更像是`JavaScript`中的`Proxy`，我们直接可以直接对描述器实例对象就行取值、赋值、删除操作，而这些操作均会被`__get__()`、`__set__()`、`__delete__()`拦截并代理。与`JavaScript`不同的是，描述器类型的实例只有在被**赋值给属性**后，才能进行拦截。
+
+* <span style='color:cyan'>`__get__(self, instance, owner)`</span>：查找描述器属性时调用。
+
+* <span style='color:cyan'>`__set__(self, instance, value)`</span>：给描述器属性赋值时调用。
+
+* <span style='color:cyan'>`__delete__(self, instance)`</span>：移除描述器属性时调用。
+
+    ```python
+    class AttrProxy:
+        value=None
+        def __get__(self, instance, owner):
+            print("in __get__()")
+            return self.value
+    
+        def __set__(self, instance, value):
+            print("in __set__()")
+            self.value = value
+    
+    class Attach:
+        data=AttrProxy()
+        def __init__(self, value):
+            self.data = value
+    
+        def print(self):
+            print(self.data)
+    
+    test=Attach(10)
+    # in __set__()
+    test.print()
+    # in __get__()
+    # 10
+    print(test.data)
+    # in __get__()
+    # 10
+    ```
+
+#### 🧨 `super()`
+
+Python 提供的内置函数中有两个是与面向对象编程密切相关的：一个是`staticmethod()`装饰器，它 <u>用于声明类的静态方法</u> ；另一个是`super()`，它用于在子类中 <u>调用父类的方法与属性</u> 。除了我们常用的`super().func()`的调用方法，`super()`还有其他调用方式。我们使用`help(super)`来查看Python给我们提供的解释：
+
+   ```
+class super(object)
+ |  super() -> same as super(__class__, <first argument>)
+ |  super(type) -> unbound super object
+ |  super(type, obj) -> bound super object; requires isinstance(obj, type)
+ |  super(type, type2) -> bound super object; requires issubclass(type2, type)
+ |  ...
+   ```
+
+对于`super`我们的关注点主要是在`super()`构造函数。观察上述运行结果，我们发现，`super()`总是接受 `super(type, other)` 的参数形式，这里的`type`实际上就是指`type`元类的实例对象即类。
+
+   * `super()`：该方式调用的同等效果参考上述描述。在一般情况下第一个参数有两种`cls`、`self`。
+
+   * `super(type)`：使用该方式调用会返回一个未绑定的`type`实例。
+
+     注意，由于返回的实例对象未绑定到`self`或者`cls`，对这返回对象的处理不会影响到`self`。
+     
+     ```python
+     class Base:
+     def hello(self):
+       print("Hello from Base")
+     
+     class Derived(Base):
+     def hello(self):
+       super(Base).hello(self)  # Hello from Base
+     
+     derived = Derived()
+     derived.hello()
+     ```
+
+   * `super(type, obj)`：使用该方法调用会将返回的`super`实例对象绑定到`obj`上，这是我们一般调用方式的实际调用方式。
+
+   * <span style='color:silver'>`super(type1, type2)`</span>：这个涉及到了Python的 **方法解析顺序**\| ``MRO`` ，后续会开专题解析。
+
+### 3. `type`与元类
+
+Python是一门面向对象的语言，几乎所有的一切都是基于类实现的，连类本身也不例外。当我们执行以下代码便可以得知用`class`声明的类本身也是`type`类的实例。
+
+```python
+class MyClass:
+    pass
+ins=MyClass()
+
+print(type(ins))        # <class '__main__.MyClass'>
+print(type(MyClass))    # <class 'type'>
+```
+
+我们将用于创建一般类的类称为 **元类**\| ``metaclass``：
+
+* **静态字段**：普通类的静态字段实际上就是使用元类生成的元类实例的实例方法与属性。
+* **默认元类 `type`** ：在定义类时使用`class MyClass(*args, metaclass=MyMetaClass)`为指定元类。如果没有指定元类，Python则会指定默认元类`type`作为该类的元类。Python的内置类的元类都是`type`。
+
+为了更好的了解元类，我们可以详细学习下`type()`方法。我们执行`help(type)`有如下结果：
+
+```shell
+class type(object)
+ |  type(object) -> the object's type
+ |  type(name, bases, dict, **kwds) -> a new type
+ |  
+ |  Methods defined here:
+ |
+ |  __call__(self, /, *args, **kwargs)		Call self as a function
+ |  __delattr__(self, name, /)			Implement delattr(self, name)
+ |  __dir__(self, /)				Specialized __dir__ 
+ | 							implementation for types
+ |  __getattribute__(self, name, /)		Return getattr(self, name)
+ |  __init__(self, /, *args, **kwargs)		Initialize self.  See 
+ |							help(type(self)) for 
+ | 							accurate signature
+ |  __instancecheck__(self, instance, /)	Check if an object is 
+ | 							an instance
+ |  __repr__(self, /)Return repr(self)
+ |  __setattr__(self, name, value, /)		Implement setattr(self, 
+ | 							name, value)
+ |  __sizeof__(self, /)				Return memory consumption
+ | 							of the type object
+ |  __subclasscheck__(self, subclass, /)	Check if a class is a subclass
+ |  __subclasses__(self, /)			Return a list of immediate 
+ | 							subclasses
+ |  mro(self, /)				Return a type's method 
+ | 							resolution order
+ |  ----------------------------------------------------------------------
+ |  Class methods defined here:
+ |  
+ |  __prepare__(...)
+ |      __prepare__() -> dict
+ |      used to create the namespace for the class statement
+ |  
+ |  ----------------------------------------------------------------------
+ |  Static methods defined here:
+ |  
+ |  __new__(*args, **kwargs)
+ |      Create and return a new object.  See help(type) for accurate signature.
+ |  
+ |  ----------------------------------------------------------------------
+ |  Data descriptors defined here:
+ |  
+ |  __abstractmethods__
+ |  __dict__
+ |  __text_signature__
+ |  
+ |  ----------------------------------------------------------------------
+ |  Data and other attributes defined here:
+ |  
+ |  __base__ = <class 'object'>
+ |      The base class of the class hierarchy.
+ |      
+ |      When called, it accepts no arguments and returns a new featureless
+ |      instance that has no instance attributes and cannot be given any.
+ |  
+ |  __bases__ = (<class 'object'>,)
+ |  __basicsize__ = 880
+ |  __dictoffset__ = 264
+ |  __flags__ = 2148293632
+ |  __itemsize__ = 40
+ |  __mro__ = (<class 'type'>, <class 'object'>)
+ |  __weakrefoffset__ = 368
+```
+
+我们主要关注`type`的构造函数与`type`类型实例的实例方法，即类的自带静态方法。
+
+* **`type()`**：根据上述描述可知，该方法的的用法除了用于判断一个实例的类，还可以用`type(name, bases, dct)`创建一个类。
+* **实例方法**：类的自带静态方法实际上就是类的**魔术方法**，我们可以通过重写类的魔术方法为更好的处理类实例的生命周期以及使用。
+
+我们也可以定制自己的元类。我们在创建类时继承`type`便创建了一个元类。元类中的某些**魔术方法**实现方式也与普通类不一样。
+
+* **`__new__(cls, name, bases, dict)`**：用于创建元类的实例对象即元类为该类的类。需要注意的是，这里的`cls`是实际上的类对象。这个`cls`无论是普通类还是元类都是这样的。
+
+    ```python
+    class MetaClass(type):
+    def __new__(cls, name, bases, dct):
+    print(cls)				# <class '__main__.MetaClass'>
+    return super().__new__(cls, name, bases, dict)
+    
+    class MyClass(metaclass=MetaClass):
+    pass
+    ```
+    
+    下面我们解释一下`name`、`bases`、`dct`分别指什么：
+
+    * `name`：使用该元类创建类时的类名。
+    * `bases`：使用该元类创建类时指定的父类。
+    * `dct`：使用字典表示用该元类创建的类的主体。
+    
+    ```python
+    class MetaClass(type):
+        def __new__(cls, *args):
+            name, bases, dct=args
+            print(f"Create class: {name}")
+            print(f"Extends class: {bases}")
+            print(dct)
+            return super().__new__(cls, name, bases, dct)
+    
+    class MyClass(metaclass=MetaClass):
+    	def __init__(self):
+    		pass
+    ```
+    
+* **`__init__(cls, name, bases, dict)`**：用于初始化元类实例对象。
+
+* **`__call__(cls, *args, **kwargs)`**：`__call__`在普通类中是用于类实例的可调用化，即用使用函数的方式使用类实例。在这里是用于元类实例的可调用化，即处理类的构造函数。
+
+    ```python
+    class MetaClass(type):
+    def __call__(self, *args, **kwargs):
+      print('In meta __call__')
+    
+    class MyClass(metaclass=MetaClass):
+    def __init__(self):
+      pass
+    
+    test=MyClass()      # In meta __call__
+    ```
+    
+    


### PR DESCRIPTION
> This PR aims to test the GitHub process and re-upload the Python tutorials.

My work includes the following:

* Add python-tutorials: data-structure, which introduces data structures in Python.
* Add python-tutorials: control-compute, which describes how Python controls programs and computations.
* Add python-tutorials: conda.md, which explains how to use the conda command-line interface.